### PR TITLE
Scenario vectorization

### DIFF
--- a/src/macrostat/core/scenarios.py
+++ b/src/macrostat/core/scenarios.py
@@ -48,7 +48,8 @@ class Scenarios:
             default scenarios.
         scenarios: dict | None
             The scenarios to initialize the model with. If None, the default
-            scenarios will be used.
+            scenarios will be used. Scenarios should be a str:dict (name:timeseries)
+            dictionary.
         scenario_info: dict | None
             The colors to use for the scenario variables. If None, the default
             colors will be used.
@@ -283,6 +284,28 @@ class Scenarios:
         with open(json_path, "w") as f:
             json.dump(data, f)
 
+    def vectorize_scenarios(self, timeseries: dict):
+        """User-defined vectorization operations on the scenario timeseries.
+
+        By default, scenarios are defined as single-column vectors where the
+        rows (dim 0) matches the number of timesteps and the column is the
+        scenario variable or paramter. However, for users with vectorized
+        implementations, one can modify this function to create vectors of
+        shape TxK as needed
+
+        Parameters
+        ----------
+        timeseries: dict[str:torch.tensor]
+            dictionary of the scenario timeseries
+
+        Returns
+        -------
+        vectors: dict[str:torch.tensor]
+            modified scenario timeseries
+
+        """
+        return timeseries
+
     def to_nn_parameters(self, scenario: int = 0):
         """Convert the scenarios to a PyTorch ParameterDict.
 
@@ -291,12 +314,12 @@ class Scenarios:
         scenario: int
             The scenario to convert to PyTorch parameters.
         """
-        # Set the current scenario
         self.current_scenario = scenario
 
-        # In general, we keep scenarios fixed, so we set requires_grad to False
-        vscenarios = torch.nn.ParameterDict(self.timeseries[scenario])
+        vectors = self.vectorize_scenarios(self.timeseries[scenario])
+        vscenarios = torch.nn.ParameterDict(vectors)
 
+        # In general, we keep scenarios fixed, so we set requires_grad to False
         for k, tensor in vscenarios.items():
             tensor.requires_grad = k in self.calibration_variables
 

--- a/src/macrostat/sample/sampler.py
+++ b/src/macrostat/sample/sampler.py
@@ -118,7 +118,6 @@ class BaseSampler:
                 hyperparameters=self.model.parameters.hyper,
             )
 
-
             # Create new model instance with new parameters
             newmodel = self.model.__class__(
                 parameters=newparams,

--- a/src/macrostat/util/batchprocessing.py
+++ b/src/macrostat/util/batchprocessing.py
@@ -30,6 +30,7 @@ def pool_context(*args, **kwargs):
         pool.join()
         logger.debug("Process pool cleanup completed")
 
+
 def timeseries_worker(task: tuple):
     """Worker function for parallel_processor, which will execute a
     simulation with the given parameters and return the output.
@@ -73,8 +74,6 @@ def parallel_processor(
 
     # Set sharing strategy
     mp.set_sharing_strategy("file_system")
-
-
 
     if len(tasks) == 0:
         raise ValueError("No tasks to process.")


### PR DESCRIPTION
Add a function `vectorize_scenarios` that is called by `to_nn_parameters` so that users with vectorized implementations can further vectorize their scenarios.

As an example, consider a model with two sectors $a$ and $b$, one might have a markup shock $a.markup_add$ and $b.markup_add$ but in the implementation one just uses a `markup` vector. This function would allow the user to implement something like

```python
vectors["markup_add"] = torch.stack([timeseries["a.markup_add"], timeseries["b.markup_add"])
```


Tests run as before.
