### PR TITLE
Matrix outputs

### DIFF
--- a/src/macrostat/core/variables.py
+++ b/src/macrostat/core/variables.py
@@ -7,6 +7,7 @@ __credits__ = ["Karl Naumann-Woleske"]
 __license__ = "MIT"
 __maintainer__ = ["Karl Naumann-Woleske"]
 
+import copy
 import json
 import logging
 import os
@@ -370,7 +371,18 @@ class Variables:
 
     def to_pandas(self):
         """Convert the variables to a pandas DataFrame."""
-        df = pd.concat({k: pd.DataFrame(v) for k, v in self.timeseries.items()}, axis=1)
+        # Copy deep so we can delete/add without affecting core var
+        timeseries = copy.deepcopy(self.timeseries)
+
+        # Flatten matrix variables: a timeseries per row of the matrix
+        for k, v in self.timeseries.items():
+            if "matrix" in self.info[k]:
+                del timeseries[k]
+                for i, subvar in enumerate(self.info[k]["matrix"]):
+                    key = f"{k}{subvar}"
+                    timeseries[key] = v[:, i, :]
+
+        df = pd.concat({k: pd.DataFrame(v) for k, v in timeseries.items()}, axis=1)
         return df
 
     def info_to_csv(self, file_path: str, sphinx_math: bool = False):
@@ -534,6 +546,7 @@ class Variables:
                 logger.error(f"Error recording {k}:")
                 logger.error(f"State: {state_vars[k].clone().detach()}")
                 logger.error(f"Timeseries: {self.timeseries[k][t, :]}")
+                print(k)
                 raise e
 
     def verify_sfc_info(self):

--- a/src/macrostat/core/variables.py
+++ b/src/macrostat/core/variables.py
@@ -450,7 +450,9 @@ class Variables:
         # Initialize the timeseries
         self.timeseries = {}
         for k, v in self.info.items():
-            if "sectors" in v and len(v["sectors"]) > 0:
+            if "matrix" in v and len(v["sectors"]) > 0:
+                self.timeseries[k] = torch.zeros(t, len(v["sectors"]), len(v["matrix"]))
+            elif "sectors" in v and len(v["sectors"]) > 0:
                 self.timeseries[k] = torch.zeros(t, len(v["sectors"]))
             else:
                 self.timeseries[k] = torch.zeros(t, 1)
@@ -462,7 +464,9 @@ class Variables:
 
         state = {}
         for k, v in self.info.items():
-            if "sectors" in v and len(v["sectors"]) > 0:
+            if "matrix" in v and len(v["sectors"]) > 0:
+                state[k] = torch.zeros(len(v["sectors"]), len(v["matrix"]), **kwargs)
+            elif "sectors" in v and len(v["sectors"]) > 0:
                 state[k] = torch.zeros(len(v["sectors"]), **kwargs)
             else:
                 state[k] = torch.zeros(1, **kwargs)
@@ -479,14 +483,19 @@ class Variables:
         history: dict
             The history variables for the given period.
         """
-        for k, v in self.history.items():
-            steps = self.info[k]["history"]
 
-            if len(v) < steps:
-                v.insert(0, state[k].squeeze())
-            else:
-                del v[-1]
-                v.insert(0, state[k].squeeze())
+        for k, v in self.history.items():
+            try:
+                steps = self.info[k]["history"]
+
+                if len(v) < steps:
+                    v.insert(0, state[k].squeeze())
+                else:
+                    del v[-1]
+                    v.insert(0, state[k].squeeze())
+            except Exception as e:
+                logger.error(f"Update history failed for {k}. Value is {v}")
+                raise e
 
         vhistory = {}
         for k, v in self.history.items():

--- a/src/macrostat/core/variables.py
+++ b/src/macrostat/core/variables.py
@@ -344,8 +344,9 @@ class Variables:
         """
         with open(file_path, "r") as file:
             data = json.load(file)
-        timeseries = {k: torch.tensor(v) for k, v in data.items()}
-        return cls(timeseries=timeseries)
+        varinfo = {k: v["info"] for k, v in data.items()}
+        timeseries = {k: torch.tensor(v["timeseries"]) for k, v in data.items()}
+        return cls(variable_info=varinfo, timeseries=timeseries)
 
     def to_excel(self, file_path: os.PathLike):
         """Convert the variables to an Excel file.
@@ -365,7 +366,10 @@ class Variables:
         file_path: os.PathLike
             The path to the JSON file to save the timeseries to.
         """
-        dicts = {k: v.tolist() for k, v in self.timeseries.items()}
+        dicts = {
+            k: {"info": self.info[k], "timeseries": v.tolist()}
+            for k, v in self.timeseries.items()
+        }
         with open(file_path, "w") as file:
             json.dump(dicts, file)
 


### PR DESCRIPTION
# Matrix output functionality

Update to handle matrix-type state variables:
- Allow users to have state, prior and history variables that are 2D e.g. an input-output table
- To do so, users need to specify a "matrix" field in the variable's `info` dict where the field should give a list of the element names. The length of the list determines the shape of the matrix (matrix rows, sectors columns).
- Adapted the `to_pandas` function to handle correct exports. This is done by converting each row of a matrix variable `varname` into a separate column with the name `varnameRowname` where `Rowname` is taken from the "matrix" list.
- Adapt the to_json and from_json to store variable information 

All tests pass. More should be developed as models with matrix outputs are handled, e.g. the matrix-history is not currently tested.