### PR TITLE
Autograd: gradient passthrough

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,9 @@
 name: Build and test package
 
 on:
+  workflow_dispatch:
+    branches:
+      - master
   pull_request:
     branches:
       - master

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.10", "3.11"]
+        python-version: ["3.13"]
 
     steps:
     - uses: actions/checkout@v4

--- a/docs/user_guide/core/variables.rst
+++ b/docs/user_guide/core/variables.rst
@@ -59,6 +59,6 @@ Example
 A typical workflow for variables might look like:
 
 >>> variables = Variables(parameters)
->>> variables.initialize_tensors(100)
+>>> variables.initialize_tensors()
 >>> variables.record_state(0, {'x': torch.tensor([1.0])})
 >>> variables.to_json('variables.json')

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,11 +1,20 @@
 dash >=3.1.1
+dash_cytoscape
+fastparquet
 importlib_metadata==8.7.0
+matplotlib
+myst_nb
 nbsphinx
+networkx
 numpy
+openpyxl
 pandas>=2.2.3
+pydata-sphinx-theme
 pytest>=7.0.0
 pytest-cov>=4.0.0
 scipy>=1.14.1
 setuptools>=75.1.0
+sphinx-design
+sphinxcontrib-bibtex
 torch>=2.4.1
 tqdm>=4.66.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,10 @@
-importlib_metadata==8.5.0
+importlib_metadata==8.7.0
 nbsphinx
-numpy==2.1.1
-pandas==2.2.3
+numpy
+pandas>=2.2.3
 pytest>=7.0.0
 pytest-cov>=4.0.0
-scipy==1.14.1
-setuptools==75.1.0
-torch==2.4.1
-tqdm==4.66.5
+scipy>=1.14.1
+setuptools>=75.1.0
+torch>=2.4.1
+tqdm>=4.66.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+dash >=3.1.1
 importlib_metadata==8.7.0
 nbsphinx
 numpy

--- a/src/macrostat/core/behavior.py
+++ b/src/macrostat/core/behavior.py
@@ -130,7 +130,7 @@ class Behavior(torch.nn.Module):
             self.history = self.variables.update_history(self.state)
             self.prior = self.state
 
-        return None
+        return self.variables.gather_timeseries()
 
     def initialize(self):
         """Initialize the behavior.

--- a/src/macrostat/core/behavior.py
+++ b/src/macrostat/core/behavior.py
@@ -93,10 +93,10 @@ class Behavior(torch.nn.Module):
         )
         self.initialize()
 
-        for t in range(self.hyper["timesteps_initialization"]):
+        for t in range(self.hyper["timesteps_initialization"] + 1):
             self.variables.record_state(t, self.state)
 
-        for t in range(self.hyper["timesteps_initialization"]):
+        for t in range(self.hyper["timesteps_initialization"] + 1):
             self.history = self.variables.update_history(self.state)
 
         # Initialize the prior and state

--- a/src/macrostat/core/behavior.py
+++ b/src/macrostat/core/behavior.py
@@ -80,12 +80,7 @@ class Behavior(torch.nn.Module):
         torch.manual_seed(self.hyper["seed"])
 
         # Initialize the output tensors
-        self.state, self.history = self.variables.initialize_tensors(
-            t=self.hyper["timesteps"],
-            dtype=torch.float32,
-            requires_grad=self.hyper["requires_grad"],
-            device=self.hyper["device"],
-        )
+        self.state, self.history = self.variables.initialize_tensors()
 
         # Initialize the model
         logger.debug(
@@ -217,12 +212,7 @@ class Behavior(torch.nn.Module):
         torch.manual_seed(self.hyper["seed"])
 
         # Initialize the output tensors
-        self.state, _ = self.variables.initialize_tensors(
-            t=self.hyper["timesteps"],
-            dtype=torch.float32,
-            requires_grad=self.hyper["requires_grad"],
-            device=self.hyper["device"],
-        )
+        self.state, _ = self.variables.initialize_tensors()
 
         # Initialize the model
         info = f"(t=0...{self.hyper['timesteps_initialization']})"

--- a/src/macrostat/core/model.py
+++ b/src/macrostat/core/model.py
@@ -197,6 +197,31 @@ class Model:
         with torch.no_grad():
             return behavior.forward(*args, **kwargs)
 
+    def get_model_training_instance(self, scenario: int | str = 0, *args, **kwargs):
+        """Simulate the model.
+
+        Parameters
+        ----------
+        scenario: int (optional)
+            The scenario to use for the model run, defaults to 0, which
+            represents the default scenario (no shocks).
+        """
+        if isinstance(scenario, str):
+            scenario = self.scenarios.get_scenario_index(scenario)
+
+        logging.debug(f"Starting simulation. Scenario: {scenario}")
+        behavior = self.behavior(
+            self.parameters,
+            self.scenarios,
+            self.variables,
+            scenario=scenario,
+            *args,
+            **kwargs,
+        )
+        behavior = behavior.to(self.parameters["device"])
+        behavior.train()
+        return behavior
+
     def compute_theoretical_steady_state(
         self, scenario: int | str = 0, *args, **kwargs
     ):

--- a/src/macrostat/core/variables.py
+++ b/src/macrostat/core/variables.py
@@ -445,18 +445,12 @@ class Variables:
         """
         return {}
 
-    def initialize_tensors(self, t: int, **kwargs):
+    def initialize_tensors(self):
         """Initialize the output tensors, creating two different dictionaries.
         First, a dictionary for the state variables (i.e. those that require
         only t-1 information, but no history) and second a dictionary for the
         history variables (i.e. those that require information from further
-        previous periods). This distinction is important for PyTorch based
-        simulations to reduce memory usage.
-
-        Parameters
-        ----------
-        t: int
-            The number of periods to initialize the tensors for.
+        previous periods).
         """
         # State variables (only t-1 information)
         state_vars = self.new_state()

--- a/src/macrostat/core/variables.py
+++ b/src/macrostat/core/variables.py
@@ -58,6 +58,10 @@ class Variables:
         else:
             self.parameters = Parameters()
 
+        self.tensor_kwargs = {
+            k: self.parameters[k] for k in ["device", "requires_grad"]
+        }
+
         if variable_info is None:
             self.info = self.get_default_variables()
         else:
@@ -455,7 +459,7 @@ class Variables:
             The number of periods to initialize the tensors for.
         """
         # State variables (only t-1 information)
-        state_vars = self.new_state(**kwargs)
+        state_vars = self.new_state()
 
         # History variables (v["history"] rows)
         self.history = {}
@@ -464,15 +468,7 @@ class Variables:
                 self.history[k] = []
 
         # Initialize the timeseries
-        self.timeseries = {}
-        for k, v in self.info.items():
-            if "matrix" in v and len(v["sectors"]) > 0:
-                self.timeseries[k] = torch.zeros(t, len(v["sectors"]), len(v["matrix"]))
-            elif "sectors" in v and len(v["sectors"]) > 0:
-                self.timeseries[k] = torch.zeros(t, len(v["sectors"]))
-            else:
-                self.timeseries[k] = torch.zeros(t, 1)
-
+        self.timeseries = {k: [] for k in self.info}
         return state_vars, self.history
 
     def new_state(self, **kwargs):
@@ -481,11 +477,13 @@ class Variables:
         state = {}
         for k, v in self.info.items():
             if "matrix" in v and len(v["sectors"]) > 0:
-                state[k] = torch.zeros(len(v["sectors"]), len(v["matrix"]), **kwargs)
+                state[k] = torch.zeros(
+                    len(v["sectors"]), len(v["matrix"]), **self.tensor_kwargs
+                )
             elif "sectors" in v and len(v["sectors"]) > 0:
-                state[k] = torch.zeros(len(v["sectors"]), **kwargs)
+                state[k] = torch.zeros(len(v["sectors"]), **self.tensor_kwargs)
             else:
-                state[k] = torch.zeros(1, **kwargs)
+                state[k] = torch.zeros(1, **self.tensor_kwargs)
 
         return state
 
@@ -543,13 +541,20 @@ class Variables:
         # Only keep the keys that are in both dictionaries
         for k in list(key_state.intersection(key_series)):
             try:
-                self.timeseries[k][t, :] = state_vars[k].clone().detach()
+                self.timeseries[k].append(state_vars[k].clone())
+                # self.timeseries[k][t, :] = state_vars[k].clone().detach()
             except Exception as e:
                 logger.error(f"Error recording {k}:")
                 logger.error(f"State: {state_vars[k].clone().detach()}")
                 logger.error(f"Timeseries: {self.timeseries[k][t, :]}")
-                print(k)
                 raise e
+
+    def gather_timeseries(self):
+        """Gather the existing timeseries "lists" into single PyTorch tensors"""
+        cat = {}
+        for k, vlist in self.timeseries.items():
+            cat[k] = torch.stack(vlist)
+        return cat
 
     def verify_sfc_info(self):
         """Verify that the sfc information in the info dictionary is complete.

--- a/src/macrostat/core/variables.py
+++ b/src/macrostat/core/variables.py
@@ -502,13 +502,11 @@ class Variables:
 
         for k, v in self.history.items():
             try:
-                steps = self.info[k]["history"]
-
-                if len(v) < steps:
-                    v.insert(0, state[k].squeeze())
-                else:
+                # If the list is full we need to delete an item:
+                if len(v) >= self.info[k]["history"]:
                     del v[-1]
-                    v.insert(0, state[k].squeeze())
+                # Insert into position 0 as newest element
+                v.insert(0, state[k].squeeze())
             except Exception as e:
                 logger.error(f"Update history failed for {k}. Value is {v}")
                 raise e

--- a/src/macrostat/core/variables.py
+++ b/src/macrostat/core/variables.py
@@ -7,7 +7,6 @@ __credits__ = ["Karl Naumann-Woleske"]
 __license__ = "MIT"
 __maintainer__ = ["Karl Naumann-Woleske"]
 
-import copy
 import json
 import logging
 import os
@@ -67,10 +66,10 @@ class Variables:
         else:
             self.info = variable_info
 
-        if timeseries is None:
-            self.initialize_tensors(self.parameters.hyper["timesteps"])
-        else:
-            self.timeseries = timeseries
+        self.initialize_tensors()
+        if timeseries is not None:
+            self._timeseries_tensor_to_list(timeseries)
+            self.gather_timeseries()
 
     ############################################################################
     # Accounting Functions
@@ -372,7 +371,7 @@ class Variables:
         """
         dicts = {
             k: {"info": self.info[k], "timeseries": v.tolist()}
-            for k, v in self.timeseries.items()
+            for k, v in self.gather_timeseries().items()
         }
         with open(file_path, "w") as file:
             json.dump(dicts, file)
@@ -380,7 +379,7 @@ class Variables:
     def to_pandas(self):
         """Convert the variables to a pandas DataFrame."""
         # Copy deep so we can delete/add without affecting core var
-        timeseries = copy.deepcopy(self.timeseries)
+        timeseries = self.gather_timeseries()
 
         # Flatten matrix variables: a timeseries per row of the matrix
         for k, v in self.timeseries.items():
@@ -462,7 +461,8 @@ class Variables:
                 self.history[k] = []
 
         # Initialize the timeseries
-        self.timeseries = {k: [] for k in self.info}
+        self.timeseries_list = {k: [] for k in self.info}
+        self.timeseries = self.gather_timeseries()
         return state_vars, self.history
 
     def new_state(self, **kwargs):
@@ -524,7 +524,7 @@ class Variables:
             The state variables to record.
         """
         key_state = set(state_vars.keys())
-        key_series = set(self.timeseries.keys())
+        key_series = set(self.timeseries_list.keys())
 
         # Warn if there are keys that are in the state variables
         # but not in the timeseries
@@ -535,19 +535,42 @@ class Variables:
         # Only keep the keys that are in both dictionaries
         for k in list(key_state.intersection(key_series)):
             try:
-                self.timeseries[k].append(state_vars[k].clone())
+                self.timeseries_list[k].append(state_vars[k].clone())
                 # self.timeseries[k][t, :] = state_vars[k].clone().detach()
             except Exception as e:
                 logger.error(f"Error recording {k}:")
                 logger.error(f"State: {state_vars[k].clone().detach()}")
-                logger.error(f"Timeseries: {self.timeseries[k][t, :]}")
+                logger.error(f"Timeseries: {self.timeseries_list[k][t, :]}")
                 raise e
+
+        self.gather_timeseries()
+
+    def _timeseries_tensor_to_list(self, tensordict):
+        """Populate the self.timeseries_list given a tensor (e.g. from the
+        initialization or similar. This ensures the gather_timeseries has the
+        correct underlying info
+        """
+        new = {}
+        for k, v in tensordict.items():
+            new[k] = [v[i] for i in range(v.shape[0])]
+        self.timeseries_list.update(new)
 
     def gather_timeseries(self):
         """Gather the existing timeseries "lists" into single PyTorch tensors"""
         cat = {}
-        for k, vlist in self.timeseries.items():
-            cat[k] = torch.stack(vlist)
+        t = self.parameters["timesteps"]
+
+        for k, v in self.timeseries_list.items():
+            if not v:
+                cat[k] = torch.tensor(t * [float("nan")])
+            else:
+                new = torch.stack(v)
+                if new.shape[0] < t:
+                    none_to_add = torch.ones(t - new.shape[0], *new.shape[1:])
+                    new = torch.cat([new, float("nan") * none_to_add], dim=0)
+                cat[k] = new
+
+        self.timeseries = cat
         return cat
 
     def verify_sfc_info(self):

--- a/src/macrostat/models/GL06SIMEX/behavior.py
+++ b/src/macrostat/models/GL06SIMEX/behavior.py
@@ -48,7 +48,6 @@ class BehaviorGL06SIMEX(Behavior):
         scenario: int
             The scenario to use for the model.
         """
-
         if parameters is None:
             parameters = ParametersGL06SIMEX()
         if scenarios is None:

--- a/tests/core/variables_test.py
+++ b/tests/core/variables_test.py
@@ -248,17 +248,16 @@ class TestVariables:
 
     def test_compare_to_variables(self):
         """Test the compare function"""
-        # Create two Variables objects with different values
-        v1 = Variables(variable_info=self.variable_info, parameters=self.params)
-        v2 = Variables(variable_info=self.variable_info, parameters=self.params)
-
-        # Initialize tensors with different values
-        v1.initialize_tensors(100)
-        v2.initialize_tensors(100)
-
-        # Set different values
-        v1.timeseries["householdWealth"][:] = 100
-        v2.timeseries["householdWealth"][:] = 200
+        v1 = Variables(
+            variable_info=self.variable_info,
+            parameters=self.params,
+            timeseries={"householdWealth": 100 * torch.ones(self.params["timesteps"])},
+        )
+        v2 = Variables(
+            variable_info=self.variable_info,
+            parameters=self.params,
+            timeseries={"householdWealth": 200 * torch.ones(self.params["timesteps"])},
+        )
 
         # Compare the variables
         diff, rel_diff = v1.compare(v2)
@@ -278,17 +277,16 @@ class TestVariables:
 
     def test_compare_to_pandas(self):
         """Test the compare function"""
-        # Create two Variables objects with different values
-        v1 = Variables(variable_info=self.variable_info, parameters=self.params)
-        v2 = Variables(variable_info=self.variable_info, parameters=self.params)
-
-        # Initialize tensors with different values
-        v1.initialize_tensors(100)
-        v2.initialize_tensors(100)
-
-        # Set different values
-        v1.timeseries["householdWealth"][:] = 100
-        v2.timeseries["householdWealth"][:] = 200
+        v1 = Variables(
+            variable_info=self.variable_info,
+            parameters=self.params,
+            timeseries={"householdWealth": 100 * torch.ones(self.params["timesteps"])},
+        )
+        v2 = Variables(
+            variable_info=self.variable_info,
+            parameters=self.params,
+            timeseries={"householdWealth": 200 * torch.ones(self.params["timesteps"])},
+        )
 
         # Compare the variables
         diff, rel_diff = v1.compare(v2.to_pandas())
@@ -313,12 +311,15 @@ class TestVariables:
 
     def test_json_io(self, tmp_path):
         """Test JSON I/O operations"""
-        # Create Variables object with some data
-        v1 = Variables(variable_info=self.variable_info, parameters=self.params)
-        state, _ = v1.initialize_tensors(100)
-        state["householdWealth"][:] = 100
-        state["householdConsumption"][:] = 50
-        state["firmProfit"][:] = 25
+        t = self.params["timesteps"]
+        data = {
+            "householdWealth": 100 * torch.ones(t),
+            "householdConsumption": 50 * torch.ones(t),
+            "firmProfit": 25 * torch.ones(t),
+        }
+        v1 = Variables(
+            variable_info=self.variable_info, parameters=self.params, timeseries=data
+        )
 
         # Save to JSON
         json_path = tmp_path / "variables.json"
@@ -341,12 +342,18 @@ class TestVariables:
 
     def test_to_pandas(self):
         """Test conversion to pandas DataFrame"""
+
+        t = self.params["timesteps"]
+        data = {
+            "householdWealth": 100 * torch.ones(t),
+            "householdConsumption": 50 * torch.ones(t),
+            "firmProfit": 25 * torch.ones(t),
+        }
+
         # Create Variables object with some data
-        v = Variables(variable_info=self.variable_info, parameters=self.params)
-        v.initialize_tensors(100)
-        v.timeseries["householdWealth"][:] = 100
-        v.timeseries["householdConsumption"][:] = 50
-        v.timeseries["firmProfit"][:] = 25
+        v = Variables(
+            variable_info=self.variable_info, parameters=self.params, timeseries=data
+        )
 
         # Convert to pandas
         df = v.to_pandas()
@@ -418,7 +425,7 @@ class TestVariables:
     def test_initialize_tensors(self):
         """Test tensor initialization"""
         v = Variables(variable_info=self.variable_info, parameters=self.params)
-        state, history = v.initialize_tensors(100)
+        state, history = v.initialize_tensors()
 
         # Check state variables
         assert set(state.keys()) == set(self.variable_info.keys())
@@ -433,7 +440,7 @@ class TestVariables:
         # Check timeseries initialization
         assert set(v.timeseries.keys()) == set(self.variable_info.keys())
         for k in v.timeseries.keys():
-            assert v.timeseries[k].shape == (100, 1)
+            assert v.timeseries[k].shape == torch.Size([100])
 
     def test_new_state(self):
         """Test new state initialization"""
@@ -446,7 +453,7 @@ class TestVariables:
     def test_update_history(self):
         """Test history update mechanism"""
         v = Variables(variable_info=self.variable_info, parameters=self.params)
-        state, _ = v.initialize_tensors(100)
+        state, _ = v.initialize_tensors()
 
         # Update history multiple times
         for i in range(3):
@@ -470,7 +477,7 @@ class TestVariables:
     def test_record_state(self, caplog):
         """Test recording of state variables"""
         v = Variables(variable_info=self.variable_info, parameters=self.params)
-        state, _ = v.initialize_tensors(100)
+        state, _ = v.initialize_tensors()
 
         # Record state at different timesteps
         for t in range(3):


### PR DESCRIPTION
# Autograd: Gradient Passthrough

1. Implementation of a `get_model_training_instance` function in the `core/model` class that returns an instance of the models behavior that has been initialized with the model's parameters, such that it can be used by the PyTorch autodiff algos
2. Changed the handling of `self.timeseries` in the `core/variables` class:
  - when running the model, the state is cloned and appended to the `self.timeseries_list`, such that we end up with a list of tensors with defined gradients
  - a function `gather_timeseries` then stacks all of the items in the list, padding with None if it does not reach the targeted number of timesteps
  - The resulting self.timeseries can pass through the gradient (ie. non-NaN grad_fn)