### PR TITLE
Fixes: Sampler

### DIFF
--- a/src/macrostat/core/variables.py
+++ b/src/macrostat/core/variables.py
@@ -389,7 +389,9 @@ class Variables:
                     key = f"{k}{subvar}"
                     timeseries[key] = v[:, i, :]
 
-        df = pd.concat({k: pd.DataFrame(v) for k, v in timeseries.items()}, axis=1)
+        ts = {k: pd.Series(v.squeeze()) for k, v in timeseries.items()}
+        df = pd.concat(ts.values(), keys=ts.keys(), axis=1)
+        df.index.name = "time"
         return df
 
     def info_to_csv(self, file_path: str, sphinx_math: bool = False):

--- a/src/macrostat/diff/__init__.py
+++ b/src/macrostat/diff/__init__.py
@@ -1,0 +1,21 @@
+"""
+Differentiation module for MacroStat
+
+The macrostat.diff module consists of a series of classes that implement both
+a numerical and autodiff approach to differentiation of a model's output.
+
+The  module consists of the following classes
+
+.. autosummary::
+    :toctree: diff
+
+    JacobianBase
+    JacobianNumerical
+    JacobianAutodiff
+"""
+
+from .jacobian_autodiff import JacobianAutodiff
+from .jacobian_base import JacobianBase
+from .jacobian_numerical import JacobianNumerical
+
+__all__ = ["JacobianBase", "JacobianNumerical", "JacobianAutodiff"]

--- a/src/macrostat/diff/jacobian_autodiff.py
+++ b/src/macrostat/diff/jacobian_autodiff.py
@@ -1,0 +1,5 @@
+from macrostat.diff import JacobianBase
+
+
+class JacobianAutodiff(JacobianBase):
+    pass

--- a/src/macrostat/diff/jacobian_base.py
+++ b/src/macrostat/diff/jacobian_base.py
@@ -1,0 +1,2 @@
+class JacobianBase:
+    pass

--- a/src/macrostat/diff/jacobian_numerical.py
+++ b/src/macrostat/diff/jacobian_numerical.py
@@ -1,0 +1,5 @@
+from macrostat.diff import JacobianBase
+
+
+class JacobianNumerical(JacobianBase):
+    pass

--- a/src/macrostat/models/GL06SIMEX/behavior.py
+++ b/src/macrostat/models/GL06SIMEX/behavior.py
@@ -101,7 +101,6 @@ class BehaviorGL06SIMEX(Behavior):
         - LabourDemand
         - DisposableIncome
         - WageRate
-        - MoneySupply
         - HouseholdMoneyStock
 
         """
@@ -115,7 +114,6 @@ class BehaviorGL06SIMEX(Behavior):
         self.state["LabourDemand"] = torch.zeros(1)
         self.state["ExpectedDisposableIncome"] = torch.zeros(1)
         self.state["DisposableIncome"] = torch.zeros(1)
-        self.state["MoneySupply"] = torch.zeros(1)
         self.state["HouseholdMoneyStock"] = torch.zeros(1)
 
     def step(self, t: int, scenario: dict, params: dict | None = None):

--- a/src/macrostat/models/GL06SIMEX/variables.py
+++ b/src/macrostat/models/GL06SIMEX/variables.py
@@ -100,7 +100,7 @@ class VariablesGL06SIMEX(Variables):
                 "sectors": ["Household"],
                 "sfc": [("Index", "Household")],
             },
-            "LabourEarnings": {
+            "LabourIncome": {
                 "notation": r"W(t)\cdot N_s(t)",
                 "unit": "USD",
                 "history": 0,

--- a/src/macrostat/sample/sampler.py
+++ b/src/macrostat/sample/sampler.py
@@ -146,14 +146,12 @@ class BaseSampler:
         """
 
         try:
-            # Generate the Sobol points
             if points is None:
                 self.points = self.generate_parameters()
             else:
                 self.points = points
 
             # Run the parallel processing in batches to conserve memory
-            # This will write results to disk, clear memory, and proceed
             if self.batchsize is None:
                 self.batchsize = self.points.shape[0]
 
@@ -178,15 +176,11 @@ class BaseSampler:
                             f"Processing batch {batch+1:05d} of {batchcount:05d}. Elapsed {elapsed} ({elapsed/batch} per batch)"
                         )
 
-                    # Generate the tasks to run
-                    # logger.info("Generating tasks")
                     end = min([(batch + 1) * self.batchsize, self.points.shape[0]])
                     batch_tasks = self.generate_tasks(
                         points=self.points.iloc[batch * self.batchsize : end]
                     )
 
-                    # Save the parameters
-                    # logger.info("Saving parameters")
                     parameters = {
                         v[0]: v[1].parameters.get_values() for v in batch_tasks
                     }

--- a/src/macrostat/sample/sampler.py
+++ b/src/macrostat/sample/sampler.py
@@ -127,7 +127,6 @@ class BaseSampler:
                 parameters=newparams,
                 scenarios=self.model.scenarios,
                 variables=self.model.variables,
-                behavior=self.model.behavior,
                 log_level=logging.CRITICAL,  # Suppress logging
             )
 

--- a/src/macrostat/sample/sampler.py
+++ b/src/macrostat/sample/sampler.py
@@ -37,6 +37,7 @@ class BaseSampler:
         output_folder: str = "samples",
         cpu_count: int = 1,
         batchsize: int = None,
+        save_to_disk: bool = True,
         output_filetype: str = "csv",
         output_compression: str | None = None,
     ):
@@ -55,6 +56,8 @@ class BaseSampler:
             Number of CPUs to use for the parallel processing
         batchsize: int (default None)
             Size of each batch to be processed in parallel
+        save_to_disk: bool (default True)
+            Save each of the batches to disk individually
         output_filetype: str (default "csv")
             Filetype to use for the output files. Options are
             "csv", "parquet"
@@ -81,6 +84,7 @@ class BaseSampler:
         self.simulation_args = simulation_args
 
         # Set up the output folder
+        self.save_to_disk = save_to_disk
         self.output_folder = Path(output_folder)
         self.output_filetype = output_filetype
         self.output_compression = output_compression
@@ -164,6 +168,9 @@ class BaseSampler:
             )
             logger.info(f"Expecting to use {batchcount} batches")
 
+            if not self.save_to_disk:
+                all_outputs = {}
+
             for batch in range(batchcount):
                 try:
                     if verbose and batch != 0:
@@ -196,7 +203,11 @@ class BaseSampler:
                     )
 
                     # Save the outputs to disk
-                    self.save_outputs(raw_outputs, batch=batch)
+                    pd_outputs = self.transform_outputs(raw_outputs, batch=batch)
+                    if self.save_to_disk:
+                        self.save_outputs(pd_outputs, batch=batch)
+                    else:
+                        all_outputs[batch] = pd_outputs
 
                     # Clean up batch resources
                     del raw_outputs
@@ -216,14 +227,12 @@ class BaseSampler:
                 del self.tasks
             gc.collect()
 
-    def save_outputs(self, raw_outputs: list, batch: int):
-        """Save the raw outputs to disk.
+        if not self.save_to_disk:
+            names = ["batch", *all_outputs[0].index.names]
+            return pd.concat(all_outputs, axis=0, names=names)
 
-        The model's outputs are in the form of a pandas DataFrame.
-        This method should save the outputs to disk in a format that
-        can be easily read back in later. Generically, it writes a
-        CSV file with the outputs in a MultiIndex format. However,
-        this can be overwritten to save in a different format.
+    def transform_outputs(self, raw_outputs: list, batch: int):
+        """Concatenate the raw outputs into a single pandas dataframe
 
         Parameters
         ----------
@@ -234,8 +243,11 @@ class BaseSampler:
         batch: int
             Batch number to save the outputs. Assumes that
             the batchsize is constant.
+
+        Returns
+        -------
+        output: pd.DataFrame
         """
-        # Concatenate the outputs
         index_names = list(raw_outputs[0][-1].index.names)
         if all(x is None for x in index_names):
             index_names = [f"index{i+1}" for i in range(len(index_names))]
@@ -243,8 +255,26 @@ class BaseSampler:
         data = pd.concat(
             data.values(), keys=data.keys(), names=["ID"] + index_names, axis=0
         )
+        return data
 
-        # Save the outputs to batch-specific files
+    def save_outputs(self, data: pd.DataFrame, batch: int):
+        """Save the raw outputs to disk.
+
+        The model's outputs are in the form of a pandas DataFrame.
+        This method should save the outputs to disk in a format that
+        can be easily read back in later. Generically, it writes a
+        CSV file with the outputs in a MultiIndex format. However,
+        this can be overwritten to save in a different format.
+
+        Parameters
+        ----------
+        data: pd.DataFrame
+            The samples run in this dataset
+        batch: int
+            Batch number to save the outputs. Assumes that
+            the batchsize is constant.
+        """
+        # Concatenate the outputs
         if self.output_filetype == "csv":
             data.to_csv(
                 self.output_folder / f"outputs_{batch}.csv",

--- a/src/macrostat/util/batchprocessing.py
+++ b/src/macrostat/util/batchprocessing.py
@@ -52,7 +52,7 @@ def timeseries_worker(task: tuple):
     try:
         model = task[1]
         _ = model.simulate(*task[2:])
-        return (task[0], *task[2:], model.output)
+        return (task[0], *task[2:], model.variables.to_pandas())
     except Exception as e:
         logger.error(f"Worker failed for task {task[0]}: {str(e)}")
         logger.error(traceback.format_exc())


### PR DESCRIPTION
# Small fixes around the sampler class

1. Make saving the outputs to disk optional for the `BaseSampler` by having a `save_to_disk` flag, with if true proceeds as before, and otherwise returns a concat dataframe of all of the runs that were executed. This also implements a transform_raw_outputs. 
2. Fix the `Variables.to_pandas()` to drop erroneous creation of MultiIndex columns from using `pd.concat` without specifying `keys=` keyword argument
3. Correction to `GL06SIMEX` to make sure that all variables from `VariablesGL06SIMEX` represented and set in the behavior (WageEarnings was used instead of WageIncome)
4. `batchprocessing` uses `model.variables.to_pandas()` to gather the outputs. 