### PR TITLE
IOPC Docs and SFC Matrices

### DIFF
--- a/docs/models/GL06/GL06PC/transaction_matrix.csv
+++ b/docs/models/GL06/GL06PC/transaction_matrix.csv
@@ -6,6 +6,6 @@ National Income,$+Y(t)$,$-Y(t)$,,,,$0$
 Interest Earned On Bills Household,$+r(t-1)\cdot B_h(t-1)$,,$-r(t-1)\cdot B_h(t-1)$,,,$0$
 Central Bank Profits,,,$+r(t-1)\cdot B_{CB}(t-1)$,$-r(t-1)\cdot B_{CB}(t-1)$,,$0$
 Taxes,$-T(t)$,,$+T(t)$,,,$0$
-Change in Money Stock,$+H_h(t)$,,,,$-H_{s}(t)$,$0$
-Change in Bill Stock,$+B_h(t)$,,$-B_s(t)$,,$+B_{CB}(t)$,$0$
+Change in Money Stock,$+\Delta H_h(t)$,,,,$-\Delta H_{s}(t)$,$0$
+Change in Bill Stock,$+\Delta B_h(t)$,,$-\Delta B_s(t)$,,$+\Delta B_{CB}(t)$,$0$
 Total,$0$,$0$,$0$,$0$,$0$,$0$

--- a/docs/models/GL06/GL06PCEX/transaction_matrix.csv
+++ b/docs/models/GL06/GL06PCEX/transaction_matrix.csv
@@ -6,6 +6,6 @@ National Income,$+Y(t)$,$-Y(t)$,,,,$0$
 Interest Earned On Bills Household,$+r(t-1)\cdot B_h(t-1)$,,$-r(t-1)\cdot B_h(t-1)$,,,$0$
 Central Bank Profits,,,$+r(t-1)\cdot B_{CB}(t-1)$,$-r(t-1)\cdot B_{CB}(t-1)$,,$0$
 Taxes,$-T(t)$,,$+T(t)$,,,$0$
-Change in Money Stock,$+H_h(t)$,,,,$-H_{s}(t)$,$0$
-Change in Bill Stock,$+B_h(t)$,,$-B_s(t)$,,$+B_{CB}(t)$,$0$
+Change in Money Stock,$+\Delta H_h(t)$,,,,$-\Delta H_{s}(t)$,$0$
+Change in Bill Stock,$+\Delta B_h(t)$,,$-\Delta B_s(t)$,,$+\Delta B_{CB}(t)$,$0$
 Total,$0$,$0$,$0$,$0$,$0$,$0$

--- a/docs/models/GL06/GL06SIM/transaction_matrix.csv
+++ b/docs/models/GL06/GL06SIM/transaction_matrix.csv
@@ -4,5 +4,5 @@ Consumption Supply,$-C_s(t)$,$+C_s(t)$,,$0$
 Government Supply,,$+G_s(t)$,$-G_s(t)$,$0$
 Tax Supply,$-T_s(t)$,,$+T_s(t)$,$0$
 Labour Earnings,$+W(t)\cdot N_s(t)$,$-W(t)\cdot N_s(t)$,,$0$
-Change in Money Stock,$+H_h(t)$,,$-H_s(t)$,$0$
+Change in Money Stock,$+\Delta H_h(t)$,,$-\Delta H_s(t)$,$0$
 Total,$0$,$0$,$0$,$0$

--- a/docs/models/GL06/GL06SIMEX/transaction_matrix.csv
+++ b/docs/models/GL06/GL06SIMEX/transaction_matrix.csv
@@ -4,5 +4,5 @@ Consumption Supply,$-C_s(t)$,$+C_s(t)$,,$0$
 Government Supply,,$+G_s(t)$,$-G_s(t)$,$0$
 Tax Supply,$-T_s(t)$,,$+T_s(t)$,$0$
 Labour Income,$+W(t)\cdot N_s(t)$,$-W(t)\cdot N_s(t)$,,$0$
-Change in Money Stock,$+H_h(t)$,,$-H_s(t)$,$0$
+Change in Money Stock,$+\Delta H_h(t)$,,$-\Delta H_s(t)$,$0$
 Total,$0$,$0$,$0$,$0$

--- a/src/macrostat/core/variables.py
+++ b/src/macrostat/core/variables.py
@@ -111,6 +111,7 @@ class Variables:
         self,
         mathfmt: str = "sphinx",
         non_camel_case: bool = False,
+        group_io: bool = True,
     ):
         """Calculate the theoretical balance sheet of the model based on the
         information in the info dictionary.
@@ -121,6 +122,8 @@ class Variables:
             The format to use for the math. Can be "sphinx", "myst", or "latex".
         non_camel_case: bool
             Whether to convert variable names to non-camel case.
+        group_io: bool
+            Whether to group the hyper["iosectors"] into "IO Sectors"
 
         Returns
         -------
@@ -130,14 +133,22 @@ class Variables:
         if not self.verify_sfc_info():
             raise ValueError("SFC information is not complete")
 
+        if "iosectors" in self.parameters.hyper:
+            iosectors = self.parameters.hyper["iosectors"]
+            sectors = [
+                i for i in self.parameters.hyper["sectors"] if i not in iosectors
+            ] + ["IOSectors"]
+        else:
+            iosectors = []
+            sectors = self.parameters.hyper["sectors"]
+
         bs = {}
         for k, v in self.get_stock_variables().items():
             for kind, sector in v:
                 # Set the default balance sheet section to "Current"
-                if isinstance(sector, list):
-                    sector = tuple(sector)
-                elif not isinstance(sector, tuple):
-                    sector = (sector, "Current")
+                sector = self._convert_sector_to_tuples(sector)
+                if group_io and sector[0] in iosectors:
+                    sector = ("IOSectors", sector[1])
 
                 # Convert variable name to non-camel case if requested
                 item = k.replace(sector[0], "").replace(sector[0].lower(), "")
@@ -163,19 +174,17 @@ class Variables:
             bs = bs.loc[order]
 
             # Add columns for any other sectors that are not in the sfc
-            for sector in self.parameters.hyper["sectors"]:
+            for sector in sectors:
                 if sector not in bs.columns:
                     bs[(sector, "Current")] = None
         else:
             # If there are no stocks, create a DataFrame with the sectors and Current
             bs = pd.DataFrame(
-                columns=pd.MultiIndex.from_product(
-                    [self.parameters.hyper["sectors"], ["Current"]]
-                )
+                columns=pd.MultiIndex.from_product([sectors, ["Current"]])
             )
 
         # Sort the columns by the order of the sectors
-        bs = bs[self.parameters.hyper["sectors"]]
+        bs = bs[sectors]
 
         # Apply the math format
         bs = self._apply_math_format(bs, mathfmt)
@@ -193,6 +202,7 @@ class Variables:
         self,
         mathfmt: str = "sphinx",
         non_camel_case: bool = False,
+        group_io: bool = True,
     ):
         """Calculate the theoretical transaction matrix of the model based on the
         information in the info dictionary.
@@ -212,11 +222,23 @@ class Variables:
         if not self.verify_sfc_info():
             raise ValueError("SFC information is not complete")
 
+        if "iosectors" in self.parameters.hyper:
+            iosectors = self.parameters.hyper["iosectors"]
+            sectors = [
+                i for i in self.parameters.hyper["sectors"] if i not in iosectors
+            ] + ["IOSectors"]
+        else:
+            iosectors = []
+            sectors = self.parameters.hyper["sectors"]
+
         tm = {}
         # Capture the flows
         for k, v in self.get_flow_variables().items():
             for kind, sector in v:
+
                 sector = self._convert_sector_to_tuples(sector)
+                if group_io and sector[0] in iosectors:
+                    sector = ("IOSectors", sector[1])
 
                 # Convert variable name to non-camel case if requested
                 if non_camel_case:
@@ -241,6 +263,8 @@ class Variables:
         for k, v in self.get_stock_variables().items():
             for kind, sector in v:
                 sector = self._convert_sector_to_tuples(sector)
+                if group_io and sector[0] in iosectors:
+                    sector = ("IOSectors", sector[1])
 
                 # Change in wealth is not considered a flow
                 if "wealth" in k.lower():
@@ -254,10 +278,10 @@ class Variables:
                 item = f"Change in {item}"
 
                 if kind.lower() == "asset":
-                    notation = f"+{self.info[k]['notation']}"
+                    notation = r"+\Delta " + self.info[k]["notation"]
                 else:
                     # Only other option is that kind.lower() == "liability":
-                    notation = f"-{self.info[k]['notation']}"
+                    notation = r"-\Delta " + self.info[k]["notation"]
 
                 # Add the item to the transaction matrix
                 if item not in tm:
@@ -271,12 +295,12 @@ class Variables:
         tm = tm.loc[order]
 
         # Add columns for any other sectors that are not in the sfc
-        for sector in self.parameters.hyper["sectors"]:
+        for sector in sectors:
             if sector not in tm.columns:
                 tm[(sector, "Current")] = None
 
         # Sort the columns by the order of the sectors
-        tm = tm.loc[:, self.parameters.hyper["sectors"]]
+        tm = tm.loc[:, sectors]
 
         # Add the total column to the end
         tm["Total"] = 0

--- a/src/macrostat/models/IOPC/variables.py
+++ b/src/macrostat/models/IOPC/variables.py
@@ -110,7 +110,7 @@ class VariablesIOPC(Variables):
             # Consumption and Production
             "RealConsumptionHousehold": {
                 "notation": r"c(t)",
-                "unit": "USD",
+                "unit": "RU",
                 "history": 0,
                 "sectors": ["Household"],
                 "sfc": [("Index", "Household")],
@@ -124,7 +124,7 @@ class VariablesIOPC(Variables):
             },
             "RealConsumptionGovernment": {
                 "notation": r"g(t)",
-                "unit": "USD",
+                "unit": "RU",
                 "history": 0,
                 "sectors": ["Government"],
                 "sfc": [("Index", "Government")],
@@ -138,14 +138,14 @@ class VariablesIOPC(Variables):
             },
             "RealGrossOutput": {
                 "notation": r"x_i(t)",
-                "unit": "USD",
+                "unit": "RU_i",
                 "history": 0,
                 "sectors": iosectors,
                 "sfc": [("Index", "Production")],
             },
             "RealFinalDemand": {
                 "notation": r"d_i(t)",
-                "unit": "USD",
+                "unit": "RU_i",
                 "history": 0,
                 "sectors": iosectors,
                 "sfc": [("Index", "Production")],

--- a/src/macrostat/models/IOPC/variables.py
+++ b/src/macrostat/models/IOPC/variables.py
@@ -115,6 +115,13 @@ class VariablesIOPC(Variables):
                 "sectors": ["Household"],
                 "sfc": [("Index", "Household")],
             },
+            "NominalConsumptionHousehold": {
+                "notation": r"p_c(t)c(t)",
+                "unit": "USD",
+                "history": 0,
+                "sectors": ["Household"],
+                "sfc": [("Outflow", "Household"), ("Inflow", "IOSectors")],
+            },
             "RealConsumptionGovernment": {
                 "notation": r"g(t)",
                 "unit": "USD",
@@ -122,15 +129,22 @@ class VariablesIOPC(Variables):
                 "sectors": ["Government"],
                 "sfc": [("Index", "Government")],
             },
+            "NominalConsumptionGovernment": {
+                "notation": r"p_g(t) g(t)",
+                "unit": "USD",
+                "history": 0,
+                "sectors": ["Government"],
+                "sfc": [("Outflow", "Government"), ("Inflow", "IOSectors")],
+            },
             "RealGrossOutput": {
-                "notation": r"x(t)",
+                "notation": r"x_i(t)",
                 "unit": "USD",
                 "history": 0,
                 "sectors": iosectors,
                 "sfc": [("Index", "Production")],
             },
             "RealFinalDemand": {
-                "notation": r"p_g(t) \cdot g(t)",
+                "notation": r"d_i(t)",
                 "unit": "USD",
                 "history": 0,
                 "sectors": iosectors,
@@ -138,7 +152,7 @@ class VariablesIOPC(Variables):
             },
             # Prices and Price-indices
             "Prices": {
-                "notation": r"p_g(t) \cdot g(t)",
+                "notation": r"P_i(t)",
                 "unit": "USD",
                 "history": 0,
                 "sectors": iosectors,
@@ -171,7 +185,7 @@ class VariablesIOPC(Variables):
                 "unit": "USD",
                 "history": 0,
                 "sectors": ["Macroeconomy"],
-                "sfc": [("Outflow", "Production"), ("Inflow", "Household")],
+                "sfc": [("Outflow", "S1"), ("Inflow", "Household")],
             },
             "InterestEarnedOnBillsHousehold": {
                 "notation": r"r(t-1)\cdot B_h(t-1)",


### PR DESCRIPTION
# Documentation of 3IO-PC

## Features
- Update the units and notation of the IOPC variables
- Add $\Delta$ to the balance sheet item changes recorded in the transaction matrix
- Automatically group the `iosectors` items into an "IOSectors" column for the transaction and balance sheets