### PR TITLE
Differentiation tools

### DIFF
--- a/docs/models/GL06/GL06SIMEX/hyperparameters.csv
+++ b/docs/models/GL06/GL06SIMEX/hyperparameters.csv
@@ -6,3 +6,4 @@ sectors,,,"['Household', 'Production', 'Government']"
 seed,,,42
 timesteps,,,100
 timesteps_initialization,,,1
+vector_sectors,,,[]

--- a/docs/models/Testing/LINEAR2D/index.rst
+++ b/docs/models/Testing/LINEAR2D/index.rst
@@ -1,0 +1,24 @@
+========
+LINEAR2D
+========
+
+.. toctree::
+   :maxdepth: 1
+
+   ../LINEAR2D_parameters.rst
+   ../LINEAR2D_scenarios.rst
+   ../LINEAR2D_variables.rst
+
+
+The main testing model is :class:`macrostat.models.LINEAR2D.LINEAR2D`, a 2D
+linear system with dynamics
+
+.. math::
+
+   x_{t+1} = A x_t,
+
+where :math:`x_t` is a 2D state vector and :math:`A` is a fully parameterised
+2x2 matrix. This model has an analytical Jacobian, so it is used in the
+``tests/diff/diff_test.py`` unit tests and in the
+``offline/macrostat_testing/calib_example.py`` script to validate the
+implementation of :mod:`macrostat.diff`.

--- a/docs/models/Testing/LINEAR2D_parameters.rst
+++ b/docs/models/Testing/LINEAR2D_parameters.rst
@@ -1,0 +1,27 @@
+==========
+Parameters
+==========
+
+The 2D linear testing model :class:`macrostat.models.LINEAR2D.LINEAR2D` has the
+following parameters:
+
+- ``a11``, ``a12``, ``a21``, ``a22`` – entries of the 2x2 transition matrix
+  :math:`A` in :math:`x_{t+1} = A x_t`.
+- ``x0_1``, ``x0_2`` – entries of the initial state :math:`x_0`.
+
+All parameters are scalars with broad bounds (default :math:`[-10, 10]`).
+
+Hyperparameters
+===============
+
+.. csv-table::
+   :file: hyperparameters.csv
+   :header-rows: 1
+
+
+Parameters
+==========
+
+.. csv-table::
+   :file: parameters.csv
+   :header-rows: 1

--- a/docs/models/Testing/LINEAR2D_scenarios.rst
+++ b/docs/models/Testing/LINEAR2D_scenarios.rst
@@ -1,0 +1,8 @@
+=========
+Scenarios
+=========
+
+The LINEAR2D model does not use any exogenous shocks or time-varying scenario
+series. Its :class:`macrostat.models.LINEAR2D.ScenariosLINEAR2D` class provides
+an empty default scenario dictionary and exists primarily to satisfy the
+standard MacroStat model interface.

--- a/docs/models/Testing/LINEAR2D_variables.rst
+++ b/docs/models/Testing/LINEAR2D_variables.rst
@@ -1,0 +1,15 @@
+=========
+Variables
+=========
+
+The LINEAR2D model exposes a single variable via
+ :class:`macrostat.models.LINEAR2D.VariablesLINEAR2D`:
+
+- ``State`` – the 2D state vector :math:`x_t` recorded at each timestep.
+
+Internally this is stored as a tensor of shape ``(timesteps, 2)``.
+
+
+.. csv-table::
+   :file: variables.csv
+   :header-rows: 1

--- a/docs/models/Testing/index.rst
+++ b/docs/models/Testing/index.rst
@@ -1,0 +1,12 @@
+================
+Testing models
+================
+
+MacroStat includes a small number of synthetic models that are not intended to
+represent real economies, but rather to serve as testbeds for the numerical and
+autodiff tooling.
+
+.. toctree::
+   :maxdepth: 1
+
+   LINEAR2D/index.rst

--- a/docs/models/index.rst
+++ b/docs/models/index.rst
@@ -13,3 +13,4 @@ This section contains the documentation of the models available in MacroStat.
    GL06/index.rst
    IOPC/IOPC.ipynb
    NK3E/NK3E.ipynb
+   Testing/index.rst

--- a/docs/user_guide/diff.rst
+++ b/docs/user_guide/diff.rst
@@ -1,0 +1,111 @@
+Differentiability and Jacobian Tools
+====================================
+
+This page describes the :mod:`macrostat.diff` module, which provides utilities
+for computing and validating Jacobians of MacroStat models using PyTorch.
+
+Overview
+--------
+
+The differentiability tools are designed for two use cases:
+
+* **Development-time checks** that a model is differentiable and that
+  gradients are sensible (no NaNs/Infs, forward vs reverse AD match, etc.).
+* **Calibration and analysis** that require Jacobians or gradient information
+  with respect to model parameters.
+
+The core pieces live in :mod:`macrostat.diff`:
+
+* :class:`macrostat.diff.JacobianBase`
+* :class:`macrostat.diff.JacobianAutograd`
+* :class:`macrostat.diff.JacobianNumerical`
+* :func:`macrostat.diff.check_model_differentiability`
+
+
+Quick start
+-----------
+
+Given a MacroStat model instance (for example :class:`macrostat.models.GL06SIMEX`
+or the small linear test model :class:`macrostat.models.LINEAR2D`), you can
+define a scalar loss and compute gradients as follows:
+
+.. code-block:: python
+
+    import torch
+    from macrostat.models import get_model
+    from macrostat.diff import JacobianAutograd, JacobianNumerical
+
+    # Build a model
+    ModelClass = get_model("LINEAR2D")
+    model = ModelClass()
+
+    # Define a loss on the model outputs
+    target = torch.tensor([1.0, 0.0])
+
+    def loss_fn(output: dict[str, torch.Tensor]) -> torch.Tensor:
+        y = output["State"][-1]  # final 2D state
+        return torch.nn.functional.mse_loss(y, target)
+
+    # Autograd-based gradients
+    jac_auto = JacobianAutograd(model)
+    grads_rev = jac_auto.compute(loss_fn=loss_fn, mode="rev")
+
+    # Numerical finite-difference gradients
+    jac_num = JacobianNumerical(model, epsilon=1e-5)
+    grads_num = jac_num.compute(loss_fn=loss_fn, mode="central")
+
+
+High-level differentiability check
+----------------------------------
+
+For a more complete diagnostic, use
+:func:`macrostat.diff.check_model_differentiability`:
+
+.. code-block:: python
+
+    from macrostat.diff import check_model_differentiability
+
+    report = check_model_differentiability(
+        model=model,
+        loss_fn=loss_fn,
+        scenario=0,
+        rtol=1e-5,
+        atol=1e-8,
+        compare_forward_reverse=True,
+        compare_numerical=True,
+        numerical_mode="central",
+        epsilon=1e-5,
+    )
+
+    print(report.summary())
+
+The resulting :class:`macrostat.diff.DifferentiabilityReport` contains:
+
+* ``nan_or_inf`` – whether any gradient contains NaNs or Infs.
+* ``rel_err_fwd_rev`` – relative discrepancy between forward- and reverse-mode
+  autograd gradients.
+* ``rel_err_autodiff_num`` – relative discrepancy between autograd and
+  numerical finite-difference gradients.
+
+Rather than only returning a pass/fail flag, the report is intended to help
+you interpret *how accurate* the gradients are (e.g. "accurate to about
+``1e-3`` relative error" on a given model and loss).
+
+
+Test model: LINEAR2D
+--------------------
+
+To validate the implementation itself, MacroStat ships with a tiny linear
+test model :class:`macrostat.models.LINEAR2D.LINEAR2D`. Its dynamics are:
+
+.. math::
+
+    x_{t+1} = A x_t,
+
+where :math:`x_t` is a 2D state vector and :math:`A` is a fully parameterised
+2x2 matrix. This model has an analytical Jacobian, so it is used
+in the test suite to confirm that:
+
+* Forward and reverse autograd agree to high precision, and
+* Autograd gradients match finite-difference gradients up to a small relative
+  error.

--- a/docs/user_guide/index.rst
+++ b/docs/user_guide/index.rst
@@ -11,6 +11,7 @@ see :ref:`api`.
 
    Getting Started <getting_started>
    Core Model Structure <core/index>
+   Differentiability and Jacobians <diff>
    Causality Analysis <causality>
    Parameter Space Sampling <sample>
    LaTeX Interfaces <latex_interfaces>

--- a/src/macrostat/core/behavior.py
+++ b/src/macrostat/core/behavior.py
@@ -175,22 +175,26 @@ class Behavior(torch.nn.Module):
         dict
             A dictionary with the updated parameters.
         """
-        # Generate index vector per sector
-        n = len(self.hyper["vector_sectors"])
-        one, zero = torch.ones(n), torch.zeros(n)
-        sec_vectors = {
-            s: torch.where(torch.arange(n) == i, one, zero)
-            for i, s in enumerate(self.hyper["vector_sectors"])
-        }
+        # Optional sectoral structure for vector/matrix parameters
+        vsecs = self.hyper.get("vector_sectors", [])
+        n = len(vsecs)
+        if n > 0:
+            one, zero = torch.ones(n), torch.zeros(n)
+            sec_vectors = {
+                s: torch.where(torch.arange(n) == i, one, zero)
+                for i, s in enumerate(vsecs)
+            }
 
-        # Generate index matrices per sector pair
-        sec = self.hyper["vector_sectors"]
-        pairs = [(row, col) for row in sec for col in sec]
-        one, zero = torch.ones(n, n), torch.zeros(n, n)
-        sec_matrices = {
-            s: torch.where(torch.arange(n * n).reshape(n, n) == i, one, zero)
-            for i, s in enumerate(pairs)
-        }
+            # Generate index matrices per sector pair
+            pairs = [(row, col) for row in vsecs for col in vsecs]
+            one, zero = torch.ones(n, n), torch.zeros(n, n)
+            sec_matrices = {
+                s: torch.where(torch.arange(n * n).reshape(n, n) == i, one, zero)
+                for i, s in enumerate(pairs)
+            }
+        else:
+            sec_vectors = {}
+            sec_matrices = {}
 
         params = {}
         for key, value in self.params.items():
@@ -205,14 +209,14 @@ class Behavior(torch.nn.Module):
                 add = torch.zeros_like(value)
                 mul = torch.ones_like(value)
 
-                if len(value.shape) == 1:
+                if len(value.shape) == 1 and sec_vectors:
                     for s, ix in sec_vectors.items():
                         if f"{s}_{key}_multiply" in scenario:
                             mul = mul * (ix * scenario[f"{s}_{key}_multiply"])
                         if f"{s}_{key}_add" in scenario:
                             add = add + (ix * scenario[f"{s}_{key}_add"])
 
-                elif len(value.shape) == 2:
+                elif len(value.shape) == 2 and sec_matrices:
                     for rowcol, ix in sec_matrices.items():
                         s = f"{rowcol[0]}_{rowcol[1]}"
 

--- a/src/macrostat/diff/__init__.py
+++ b/src/macrostat/diff/__init__.py
@@ -4,18 +4,25 @@ Differentiation module for MacroStat
 The macrostat.diff module consists of a series of classes that implement both
 a numerical and autodiff approach to differentiation of a model's output.
 
-The  module consists of the following classes
+The module consists of the following classes
 
 .. autosummary::
     :toctree: diff
 
     JacobianBase
     JacobianNumerical
-    JacobianAutodiff
+    JacobianAutograd
 """
 
-from .jacobian_autodiff import JacobianAutodiff
+from .checker import DifferentiabilityReport, check_model_differentiability
+from .jacobian_autograd import JacobianAutograd
 from .jacobian_base import JacobianBase
 from .jacobian_numerical import JacobianNumerical
 
-__all__ = ["JacobianBase", "JacobianNumerical", "JacobianAutodiff"]
+__all__ = [
+    "JacobianBase",
+    "JacobianNumerical",
+    "JacobianAutograd",
+    "DifferentiabilityReport",
+    "check_model_differentiability",
+]

--- a/src/macrostat/diff/checker.py
+++ b/src/macrostat/diff/checker.py
@@ -1,0 +1,218 @@
+"""
+High-level differentiability checks for MacroStat models.
+
+This module provides a small API to compare:
+
+- Reverse-mode vs forward-mode autograd Jacobians, and
+- Autograd vs numerical finite-difference Jacobians
+
+for a user-specified scalar loss function of model outputs.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Callable, Dict, Literal, Optional
+
+import torch
+
+from macrostat.diff.jacobian_autograd import JacobianAutograd
+from macrostat.diff.jacobian_numerical import JacobianNumerical
+
+LossFn = Callable[[Dict[str, torch.Tensor]], torch.Tensor]
+
+
+@dataclass
+class DifferentiabilityReport:
+    """Summary of differentiability checks."""
+
+    passed: bool
+    nan_or_inf: bool
+    fwd_vs_rev_ok: Optional[bool]
+    autodiff_vs_numerical_ok: Optional[bool]
+    max_abs_diff_fwd_rev: Optional[float]
+    max_abs_diff_autodiff_num: Optional[float]
+    rel_err_fwd_rev: Optional[float]
+    rel_err_autodiff_num: Optional[float]
+    details: Dict[str, dict]
+
+    def summary(self) -> str:
+        """Return a short human-readable summary."""
+        lines = []
+        lines.append(f"Passed: {self.passed}")
+        lines.append(f"NaN/Inf gradients: {self.nan_or_inf}")
+        if self.fwd_vs_rev_ok is not None:
+            lines.append(
+                f"Forward vs reverse: rel≈{self.rel_err_fwd_rev:.3e} "
+                f"(max abs diff={self.max_abs_diff_fwd_rev})"
+            )
+        if self.autodiff_vs_numerical_ok is not None:
+            lines.append(
+                f"Autograd vs numerical: rel≈{self.rel_err_autodiff_num:.3e} "
+                f"(max abs diff={self.max_abs_diff_autodiff_num})"
+            )
+        return "\n".join(lines)
+
+
+def _max_abs_diff_dict(
+    a: Dict[str, torch.Tensor],
+    b: Dict[str, torch.Tensor],
+) -> float:
+    """Compute the maximum absolute difference between two grad dicts."""
+    max_diff = 0.0
+    for name in a.keys() & b.keys():
+        diff = (a[name] - b[name]).abs().max().item()
+        max_diff = max(max_diff, float(diff))
+    return max_diff
+
+
+def _max_abs_val_dict(
+    grads: Dict[str, torch.Tensor],
+) -> float:
+    """Maximum absolute value across all gradients in a dict."""
+    max_val = 0.0
+    for g in grads.values():
+        if g.numel() == 0:
+            continue
+        val = g.abs().max().item()
+        max_val = max(max_val, float(val))
+    return max_val
+
+
+def _has_nan_or_inf(grads: Dict[str, torch.Tensor]) -> bool:
+    for g in grads.values():
+        if not torch.isfinite(g).all():
+            return True
+    return False
+
+
+def check_model_differentiability(
+    model,
+    loss_fn: LossFn,
+    scenario: int | str = 0,
+    target: Literal["parameters"] = "parameters",
+    rtol: float = 1e-5,
+    atol: float = 1e-8,
+    compare_forward_reverse: bool = True,
+    compare_numerical: bool = True,
+    numerical_mode: Literal["central", "forward", "backward"] = "central",
+    epsilon: float = 1e-5,
+    raise_on_failure: Optional[bool] = None,
+) -> DifferentiabilityReport:
+    """
+    Run a suite of differentiability checks on a MacroStat model.
+
+    Parameters
+    ----------
+    model :
+        MacroStat model instance.
+    loss_fn :
+        Scalar loss function of the model outputs (dict[str, torch.Tensor]).
+    scenario :
+        Scenario index or name to use.
+    target :
+        Currently only ``\"parameters\"`` is supported (placeholder for future).
+    rtol, atol :
+        Relative and absolute tolerances for comparisons.
+    compare_forward_reverse :
+        If True, compare reverse-mode and forward-mode autograd gradients.
+    compare_numerical :
+        If True, compare autograd gradients to numerical finite-difference gradients.
+    numerical_mode :
+        Finite-difference scheme to use when comparing against numerical.
+    epsilon :
+        Step size for finite differences.
+    raise_on_failure :
+        If True and checks fail, raise a RuntimeError instead of just returning
+        the report. If None, do not raise.
+    """
+    if target != "parameters":
+        raise NotImplementedError(
+            "Only target='parameters' is supported at the moment."
+        )
+
+    details: Dict[str, dict] = {}
+
+    # ------------------------------------------------------------------
+    # Autograd (reverse-mode) baseline
+    # ------------------------------------------------------------------
+    auto = JacobianAutograd(model=model, scenario=scenario)
+    grads_rev = auto.compute(loss_fn=loss_fn, mode="rev")
+    nan_or_inf = _has_nan_or_inf(grads_rev)
+    details["autograd_rev"] = {"nan_or_inf": nan_or_inf}
+
+    # ------------------------------------------------------------------
+    # Forward vs reverse comparison
+    # ------------------------------------------------------------------
+    fwd_vs_rev_ok: Optional[bool] = None
+    max_abs_diff_fwd_rev: Optional[float] = None
+    rel_err_fwd_rev: Optional[float] = None
+
+    if compare_forward_reverse:
+        grads_fwd = auto.compute(loss_fn=loss_fn, mode="fwd")
+        max_abs_diff_fwd_rev = _max_abs_diff_dict(grads_rev, grads_fwd)
+        # Scale tolerance by the typical gradient magnitude
+        scale = max(
+            _max_abs_val_dict(grads_rev),
+            _max_abs_val_dict(grads_fwd),
+            1.0,
+        )
+        rel_err_fwd_rev = max_abs_diff_fwd_rev / scale
+        fwd_vs_rev_ok = max_abs_diff_fwd_rev <= (atol + rtol * scale)
+        details["autograd_fwd"] = {
+            "max_abs_diff_fwd_rev": max_abs_diff_fwd_rev,
+            "ok": fwd_vs_rev_ok,
+            "rel_err": rel_err_fwd_rev,
+        }
+
+    # ------------------------------------------------------------------
+    # Numerical comparison
+    # ------------------------------------------------------------------
+    autodiff_vs_numerical_ok: Optional[bool] = None
+    max_abs_diff_autodiff_num: Optional[float] = None
+    rel_err_autodiff_num: Optional[float] = None
+
+    if compare_numerical:
+        num = JacobianNumerical(model=model, scenario=scenario, epsilon=epsilon)
+        grads_num = num.compute(loss_fn=loss_fn, mode=numerical_mode)
+        max_abs_diff_autodiff_num = _max_abs_diff_dict(grads_rev, grads_num)
+        scale = max(
+            _max_abs_val_dict(grads_rev),
+            _max_abs_val_dict(grads_num),
+            1.0,
+        )
+        rel_err_autodiff_num = max_abs_diff_autodiff_num / scale
+        autodiff_vs_numerical_ok = max_abs_diff_autodiff_num <= (atol + rtol * scale)
+        details["numerical"] = {
+            "max_abs_diff_autodiff_num": max_abs_diff_autodiff_num,
+            "ok": autodiff_vs_numerical_ok,
+            "rel_err": rel_err_autodiff_num,
+        }
+
+    # ------------------------------------------------------------------
+    # Overall status
+    # ------------------------------------------------------------------
+    passed_checks = [not nan_or_inf]
+    if fwd_vs_rev_ok is not None:
+        passed_checks.append(fwd_vs_rev_ok)
+    if autodiff_vs_numerical_ok is not None:
+        passed_checks.append(autodiff_vs_numerical_ok)
+
+    passed = all(passed_checks)
+
+    report = DifferentiabilityReport(
+        passed=passed,
+        nan_or_inf=nan_or_inf,
+        fwd_vs_rev_ok=fwd_vs_rev_ok,
+        autodiff_vs_numerical_ok=autodiff_vs_numerical_ok,
+        max_abs_diff_fwd_rev=max_abs_diff_fwd_rev,
+        max_abs_diff_autodiff_num=max_abs_diff_autodiff_num,
+        rel_err_fwd_rev=rel_err_fwd_rev,
+        rel_err_autodiff_num=rel_err_autodiff_num,
+        details=details,
+    )
+
+    if raise_on_failure and not passed:
+        raise RuntimeError(f"Differentiability check failed:\n{report.summary()}")
+
+    return report

--- a/src/macrostat/diff/jacobian_autodiff.py
+++ b/src/macrostat/diff/jacobian_autodiff.py
@@ -1,5 +1,0 @@
-from macrostat.diff import JacobianBase
-
-
-class JacobianAutodiff(JacobianBase):
-    pass

--- a/src/macrostat/diff/jacobian_autograd.py
+++ b/src/macrostat/diff/jacobian_autograd.py
@@ -1,0 +1,80 @@
+"""
+Autograd-based Jacobian computation for MacroStat models.
+
+This module uses PyTorch's torch.func API (functional_call, jacrev, jacfwd)
+to compute Jacobians of a user-specified loss function with respect to the
+parameters of a model's Behavior module.
+"""
+
+from __future__ import annotations
+
+from typing import Callable, Dict, Literal
+
+import torch
+from torch.func import functional_call, jacfwd, jacrev
+
+from macrostat.diff.jacobian_base import JacobianBase
+
+LossFn = Callable[[Dict[str, torch.Tensor]], torch.Tensor]
+
+
+class JacobianAutograd(JacobianBase):
+    """
+    Compute Jacobians using PyTorch's autograd function transforms.
+
+    Notes
+    -----
+    - Currently supports differentiation with respect to **parameters only**.
+    - The loss function must return a **scalar tensor**.
+    """
+
+    def compute(
+        self,
+        loss_fn: LossFn,
+        mode: Literal["rev", "fwd"] = "rev",
+    ) -> Dict[str, torch.Tensor]:
+        """
+        Compute the Jacobian of the loss with respect to the model parameters.
+
+        Parameters
+        ----------
+        loss_fn :
+            A callable that takes the output dictionary from the model
+            (as returned by ``Behavior.forward``) and returns a **scalar**
+            ``torch.Tensor`` loss.
+        mode :
+            Autograd mode to use:
+
+            - ``\"rev\"``: reverse-mode via ``torch.func.jacrev`` (default).
+            - ``\"fwd\"``: forward-mode via ``torch.func.jacfwd``.
+
+        Returns
+        -------
+        dict[str, torch.Tensor]
+            A dictionary mapping parameter names to gradient tensors of the
+            same shape as the corresponding parameters.
+        """
+        if mode not in {"rev", "fwd"}:
+            raise ValueError(f"Unsupported mode '{mode}'. Use 'rev' or 'fwd'.")
+
+        behavior, base_params = self._get_behavior_and_params()
+
+        def compute_loss(params: Dict[str, torch.Tensor]) -> torch.Tensor:
+            # Run the behavior with the provided parameters
+            output = functional_call(behavior, params, ())
+            loss = loss_fn(output)
+            if loss.ndim != 0:
+                raise ValueError(
+                    "JacobianAutograd currently expects loss_fn to return a scalar "
+                    f"tensor, but got shape {tuple(loss.shape)}."
+                )
+            return loss
+
+        if mode == "rev":
+            grads = jacrev(compute_loss)(base_params)
+        else:  # mode == "fwd"
+            grads = jacfwd(compute_loss)(base_params)
+
+        # jacrev/jacfwd return a structure matching the inputs (dict[name -> tensor])
+        # We ensure the output is a plain dict[str, Tensor]
+        return {name: g for name, g in grads.items()}

--- a/src/macrostat/diff/jacobian_base.py
+++ b/src/macrostat/diff/jacobian_base.py
@@ -1,2 +1,85 @@
+"""
+Base class and utilities for Jacobian computation in MacroStat.
+
+This module provides shared functionality for working with MacroStat models
+in a way that is compatible with PyTorch's autograd and torch.func APIs.
+"""
+
+from __future__ import annotations
+
+from typing import Dict, Tuple
+
+import torch
+
+from macrostat.core.model import Model
+
+
 class JacobianBase:
-    pass
+    """
+    Base class for Jacobian computation.
+
+    This class is responsible for:
+
+    - Constructing a training ``Behavior`` instance from a MacroStat ``Model``.
+    - Extracting the parameters of the behavior as a dictionary suitable for
+      use with :mod:`torch.func` utilities.
+    """
+
+    def __init__(self, model: Model, scenario: int | str = 0):
+        """
+        Parameters
+        ----------
+        model :
+            A MacroStat model instance (e.g. ``GL06SIMEX()``).
+        scenario :
+            Scenario index or name to use when constructing the behavior.
+        """
+        self.model = model
+        self.scenario = scenario
+
+    # ------------------------------------------------------------------
+    # Core utilities
+    # ------------------------------------------------------------------
+    def _get_behavior_and_params(
+        self,
+    ) -> Tuple[torch.nn.Module, Dict[str, torch.Tensor]]:
+        """
+        Construct a training Behavior instance and extract its parameters.
+
+        Returns
+        -------
+        behavior :
+            The behavior module obtained from
+            ``model.get_model_training_instance(scenario=...)``.
+        params :
+            A dictionary mapping parameter names to tensors, as returned by
+            ``behavior.named_parameters()``.
+        """
+        behavior = self.model.get_model_training_instance(scenario=self.scenario)
+        # Ensure we're in training mode for gradient computations
+        behavior.train()
+
+        # Convert named_parameters() iterator to a plain dict[str, Tensor]
+        # Only keep true model parameters (exclude scenario-related tensors)
+        params = {
+            name: p
+            for name, p in behavior.named_parameters()
+            if name.startswith("params.")
+        }
+        return behavior, params
+
+    # ------------------------------------------------------------------
+    # Abstract API
+    # ------------------------------------------------------------------
+    def compute(self, *args, **kwargs):
+        """
+        Placeholder for subclasses to implement Jacobian computation.
+
+        Subclasses should implement this method with a consistent interface,
+        for example:
+
+        ``compute(loss_fn=..., mode=...)``.
+        """
+        raise NotImplementedError(
+            "JacobianBase.compute() must be implemented by subclasses"
+        )

--- a/src/macrostat/diff/jacobian_numerical.py
+++ b/src/macrostat/diff/jacobian_numerical.py
@@ -1,5 +1,118 @@
-from macrostat.diff import JacobianBase
+"""
+Numerical (finite-difference) Jacobian computation for MacroStat models.
+
+This module approximates the gradient of a scalar loss with respect to the
+parameters of a model's Behavior module using finite differences.
+"""
+
+from __future__ import annotations
+
+from typing import Callable, Dict, Literal
+
+import torch
+
+from macrostat.diff.jacobian_base import JacobianBase
+
+LossFn = Callable[[Dict[str, torch.Tensor]], torch.Tensor]
 
 
 class JacobianNumerical(JacobianBase):
-    pass
+    """
+    Compute Jacobians via finite differences.
+
+    Notes
+    -----
+    - Currently supports differentiation with respect to **parameters only**.
+    - The loss function must return a **scalar tensor**.
+    """
+
+    def __init__(self, model, scenario: int | str = 0, epsilon: float = 1e-5):
+        super().__init__(model=model, scenario=scenario)
+        self.epsilon = float(epsilon)
+
+    def compute(
+        self,
+        loss_fn: LossFn,
+        mode: Literal["central", "forward", "backward"] = "central",
+    ) -> Dict[str, torch.Tensor]:
+        """
+        Compute the numerical Jacobian of the loss w.r.t. model parameters.
+
+        Parameters
+        ----------
+        loss_fn :
+            A callable that takes the output dictionary from the model
+            (as returned by ``Behavior.forward``) and returns a **scalar**
+            ``torch.Tensor`` loss.
+        mode :
+            Finite-difference scheme to use:
+
+            - ``\"central\"``: central differences (default).
+            - ``\"forward\"``: forward differences.
+            - ``\"backward\"``: backward differences.
+
+        Returns
+        -------
+        dict[str, torch.Tensor]
+            A dictionary mapping parameter names to gradient tensors of the
+            same shape as the corresponding parameters.
+        """
+        if mode not in {"central", "forward", "backward"}:
+            raise ValueError(
+                f"Unsupported mode '{mode}'. Use 'central', 'forward', or 'backward'."
+            )
+
+        behavior, base_params = self._get_behavior_and_params()
+
+        def compute_loss(params: Dict[str, torch.Tensor]) -> torch.Tensor:
+            # We re-use the same behavior instance but override parameters
+            from torch.func import functional_call
+
+            with torch.no_grad():
+                output = functional_call(behavior, params, ())
+                loss = loss_fn(output)
+                if loss.ndim != 0:
+                    raise ValueError(
+                        "JacobianNumerical currently expects loss_fn to return a scalar "
+                        f"tensor, but got shape {tuple(loss.shape)}."
+                    )
+                return loss
+
+        epsilon = self.epsilon
+
+        # Evaluate base loss once
+        base_loss = compute_loss(base_params)
+
+        jacobian: Dict[str, torch.Tensor] = {}
+
+        for name, p in base_params.items():
+            # Work on a flattened view for simplicity
+            p_flat = p.detach().clone().reshape(-1)
+            grad_flat = torch.empty_like(p_flat)
+
+            for i in range(p_flat.numel()):
+                # Prepare perturbed parameter vectors
+                if mode in {"central", "forward"}:
+                    p_pos = p_flat.clone()
+                    p_pos[i] += epsilon
+                    params_pos = dict(base_params)
+                    params_pos[name] = p_pos.reshape_as(p)
+                    loss_pos = compute_loss(params_pos)
+
+                if mode in {"central", "backward"}:
+                    p_neg = p_flat.clone()
+                    p_neg[i] -= epsilon
+                    params_neg = dict(base_params)
+                    params_neg[name] = p_neg.reshape_as(p)
+                    loss_neg = compute_loss(params_neg)
+
+                if mode == "central":
+                    grad_flat[i] = (loss_pos - loss_neg) / (2.0 * epsilon)
+                elif mode == "forward":
+                    grad_flat[i] = (loss_pos - base_loss) / epsilon
+                else:  # backward
+                    grad_flat[i] = (base_loss - loss_neg) / epsilon
+
+            jacobian[name] = grad_flat.reshape_as(p)
+
+        return jacobian

--- a/src/macrostat/models/LINEAR2D/__init__.py
+++ b/src/macrostat/models/LINEAR2D/__init__.py
@@ -1,0 +1,28 @@
+"""
+Simple 2D linear model for Jacobian testing.
+
+The macrostat.models.LINEAR2D module consists of the following classes
+
+.. autosummary::
+    :toctree: models/LINEAR2D
+
+    LINEAR2D
+    BehaviorLINEAR2D
+    ParametersLINEAR2D
+    ScenariosLINEAR2D
+    VariablesLINEAR2D
+"""
+
+from .behavior import BehaviorLINEAR2D
+from .linear2d import LINEAR2D
+from .parameters import ParametersLINEAR2D
+from .scenarios import ScenariosLINEAR2D
+from .variables import VariablesLINEAR2D
+
+__all__ = [
+    "LINEAR2D",
+    "BehaviorLINEAR2D",
+    "ParametersLINEAR2D",
+    "VariablesLINEAR2D",
+    "ScenariosLINEAR2D",
+]

--- a/src/macrostat/models/LINEAR2D/behavior.py
+++ b/src/macrostat/models/LINEAR2D/behavior.py
@@ -1,0 +1,70 @@
+"""
+Behavior for the 2D linear test model.
+
+The model evolves according to:
+
+.. math::
+    x_{t+1} = A x_t,
+
+where :math:`A` is a 2x2 matrix of parameters and :math:`x_0` is an
+initial state parameter.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import torch
+
+from macrostat.core.behavior import Behavior
+from macrostat.models.LINEAR2D.parameters import ParametersLINEAR2D
+from macrostat.models.LINEAR2D.scenarios import ScenariosLINEAR2D
+from macrostat.models.LINEAR2D.variables import VariablesLINEAR2D
+
+logger = logging.getLogger(__name__)
+
+
+class BehaviorLINEAR2D(Behavior):
+    """Behavior for the 2D linear test model."""
+
+    version = "LINEAR2D"
+
+    def __init__(
+        self,
+        parameters: ParametersLINEAR2D | None = None,
+        scenarios: ScenariosLINEAR2D | None = None,
+        variables: VariablesLINEAR2D | None = None,
+        scenario: int = 0,
+        debug: bool = False,
+    ):
+        if parameters is None:
+            parameters = ParametersLINEAR2D()
+        if scenarios is None:
+            scenarios = ScenariosLINEAR2D(parameters=parameters)
+        if variables is None:
+            variables = VariablesLINEAR2D(parameters=parameters)
+
+        super().__init__(
+            parameters=parameters,
+            scenarios=scenarios,
+            variables=variables,
+            scenario=scenario,
+            debug=debug,
+        )
+
+    def initialize(self):
+        """Initialize the 2D state from the x0 parameters."""
+        x0_1 = self.params["x0_1"]
+        x0_2 = self.params["x0_2"]
+        self.state["State"] = torch.stack([x0_1, x0_2])
+
+    def step(self, t: int, scenario: dict, params: dict | None = None):
+        """Single-step update: x_{t+1} = A x_t."""
+        a11 = self.params["a11"]
+        a12 = self.params["a12"]
+        a21 = self.params["a21"]
+        a22 = self.params["a22"]
+        A = torch.stack([a11, a12, a21, a22]).reshape(2, 2)
+
+        x_prev = self.prior["State"]
+        self.state["State"] = A @ x_prev

--- a/src/macrostat/models/LINEAR2D/linear2d.py
+++ b/src/macrostat/models/LINEAR2D/linear2d.py
@@ -1,0 +1,45 @@
+"""
+Model wrapper for the 2D linear test model.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from macrostat.core.model import Model
+from macrostat.models.LINEAR2D.behavior import BehaviorLINEAR2D
+from macrostat.models.LINEAR2D.parameters import ParametersLINEAR2D
+from macrostat.models.LINEAR2D.scenarios import ScenariosLINEAR2D
+from macrostat.models.LINEAR2D.variables import VariablesLINEAR2D
+
+logger = logging.getLogger(__name__)
+
+
+class LINEAR2D(Model):
+    """Simple 2D linear model for Jacobian testing."""
+
+    version = "LINEAR2D"
+
+    def __init__(
+        self,
+        parameters: ParametersLINEAR2D | None = ParametersLINEAR2D(),
+        variables: VariablesLINEAR2D | None = None,
+        scenarios: ScenariosLINEAR2D | None = None,
+        *args,
+        **kwargs,
+    ):
+        if parameters is None:
+            parameters = ParametersLINEAR2D()
+        if variables is None:
+            variables = VariablesLINEAR2D(parameters=parameters)
+        if scenarios is None:
+            scenarios = ScenariosLINEAR2D(parameters=parameters)
+
+        super().__init__(
+            parameters=parameters,
+            variables=variables,
+            scenarios=scenarios,
+            behavior=BehaviorLINEAR2D,
+            *args,
+            **kwargs,
+        )

--- a/src/macrostat/models/LINEAR2D/parameters.py
+++ b/src/macrostat/models/LINEAR2D/parameters.py
@@ -1,0 +1,86 @@
+"""
+Parameters for the simple 2D linear model used for Jacobian testing.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from macrostat.core.parameters import Parameters
+
+logger = logging.getLogger(__name__)
+
+
+class ParametersLINEAR2D(Parameters):
+    """Parameters for the 2D linear test model.
+
+    The model is:
+
+    .. math::
+        x_{t+1} = A x_t,
+
+    where :math:`x_t \\in \\mathbb{R}^2` and :math:`A \\in \\mathbb{R}^{2\\times 2}`.
+
+    We parameterize:
+
+    - ``a11, a12, a21, a22``: entries of :math:`A`
+    - ``x0_1, x0_2``: entries of the initial state :math:`x_0`
+    """
+
+    version = "LINEAR2D"
+
+    def get_default_parameters(self):
+        return {
+            "a11": {
+                "lower bound": -10.0,
+                "upper bound": 10.0,
+                "notation": r"a_{11}",
+                "unit": ".",
+                "value": 0.9,
+            },
+            "a12": {
+                "lower bound": -10.0,
+                "upper bound": 10.0,
+                "notation": r"a_{12}",
+                "unit": ".",
+                "value": 0.1,
+            },
+            "a21": {
+                "lower bound": -10.0,
+                "upper bound": 10.0,
+                "notation": r"a_{21}",
+                "unit": ".",
+                "value": -0.2,
+            },
+            "a22": {
+                "lower bound": -10.0,
+                "upper bound": 10.0,
+                "notation": r"a_{22}",
+                "unit": ".",
+                "value": 0.8,
+            },
+            "x0_1": {
+                "lower bound": -10.0,
+                "upper bound": 10.0,
+                "notation": r"x_{0,1}",
+                "unit": ".",
+                "value": 1.0,
+            },
+            "x0_2": {
+                "lower bound": -10.0,
+                "upper bound": 10.0,
+                "notation": r"x_{0,2}",
+                "unit": ".",
+                "value": 0.0,
+            },
+        }
+
+    def get_default_hyperparameters(self):
+        hyper = super().get_default_hyperparameters()
+        # Keep this model tiny and cheap
+        hyper["timesteps"] = 5
+        hyper["timesteps_initialization"] = 0
+        # Minimal sector info to keep core utilities happy
+        hyper.setdefault("sectors", ["Linear2D"])
+        hyper.setdefault("vector_sectors", [])
+        return hyper

--- a/src/macrostat/models/LINEAR2D/scenarios.py
+++ b/src/macrostat/models/LINEAR2D/scenarios.py
@@ -1,0 +1,43 @@
+"""
+Scenarios for the 2D linear test model.
+
+This model does not use any exogenous shocks; we keep the scenario structure
+minimal to satisfy the MacroStat interfaces.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from macrostat.core.scenarios import Scenarios
+from macrostat.models.LINEAR2D.parameters import ParametersLINEAR2D
+
+logger = logging.getLogger(__name__)
+
+
+class ScenariosLINEAR2D(Scenarios):
+    """Scenarios for the 2D linear test model."""
+
+    version = "LINEAR2D"
+
+    def __init__(
+        self,
+        scenario_info: dict | None = None,
+        parameters: ParametersLINEAR2D | None = None,
+        *args,
+        **kwargs,
+    ):
+        if parameters is None:
+            parameters = ParametersLINEAR2D()
+
+        super().__init__(
+            scenario_info=scenario_info,
+            parameters=parameters,
+            *args,
+            **kwargs,
+        )
+
+    def get_default_scenario_values(self):
+        """Return an empty scenario dictionary (no exogenous shocks)."""
+
+        return {}

--- a/src/macrostat/models/LINEAR2D/variables.py
+++ b/src/macrostat/models/LINEAR2D/variables.py
@@ -1,0 +1,52 @@
+"""
+Variables for the 2D linear test model.
+
+We expose a single variable ``State`` that records the 2D state over time.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from macrostat.core.variables import Variables
+from macrostat.models.LINEAR2D.parameters import ParametersLINEAR2D
+
+logger = logging.getLogger(__name__)
+
+
+class VariablesLINEAR2D(Variables):
+    """Variables for the 2D linear test model."""
+
+    version = "LINEAR2D"
+
+    def __init__(
+        self,
+        variable_info: dict | None = None,
+        timeseries: dict | None = None,
+        parameters: ParametersLINEAR2D | None = None,
+        *args,
+        **kwargs,
+    ):
+        if parameters is None:
+            parameters = ParametersLINEAR2D()
+
+        super().__init__(
+            variable_info=variable_info,
+            timeseries=timeseries,
+            parameters=parameters,
+            *args,
+            **kwargs,
+        )
+
+    def get_default_variables(self):
+        """Return a minimal variable info dictionary."""
+
+        return {
+            "State": {
+                "notation": r"x(t)",
+                "unit": ".",
+                "history": 0,
+                "sectors": ["Linear2D"],
+                "sfc": [("Index", "Linear2D")],
+            },
+        }

--- a/tests/diff/diff_test.py
+++ b/tests/diff/diff_test.py
@@ -1,0 +1,62 @@
+import torch
+
+from macrostat.diff import (
+    JacobianAutograd,
+    JacobianNumerical,
+    check_model_differentiability,
+)
+from macrostat.models import get_model
+
+
+class TestDiffLinear2D:
+    def setup_method(self):
+        self.model_cls = get_model("LINEAR2D")
+        self.model = self.model_cls()
+
+    def make_loss_fn(self):
+        target = torch.tensor([1.0, 0.0])
+
+        def loss_fn(output: dict[str, torch.Tensor]) -> torch.Tensor:
+            y = output["State"][-1]
+            return torch.nn.functional.mse_loss(y, target)
+
+        return loss_fn
+
+    def test_autograd_vs_numerical_close(self):
+        loss_fn = self.make_loss_fn()
+        auto = JacobianAutograd(self.model)
+        num = JacobianNumerical(self.model, epsilon=1e-5)
+
+        grads_auto = auto.compute(loss_fn=loss_fn, mode="rev")
+        grads_num = num.compute(loss_fn=loss_fn, mode="central")
+
+        for name in grads_auto:
+            ga = grads_auto[name]
+            gn = grads_num[name]
+            assert ga.shape == gn.shape
+            # Relative error should be modest for this simple linear system
+            denom = torch.maximum(ga.abs(), gn.abs()).clamp_min(1.0)
+            rel = (ga - gn).abs() / denom
+            assert rel.max().item() < 1e-2
+
+    def test_checker_reports_small_relative_errors(self):
+        loss_fn = self.make_loss_fn()
+        report = check_model_differentiability(
+            model=self.model,
+            loss_fn=loss_fn,
+            scenario=0,
+            rtol=1e-5,
+            atol=1e-8,
+            compare_forward_reverse=True,
+            compare_numerical=True,
+            numerical_mode="central",
+            epsilon=1e-5,
+        )
+
+        assert not report.nan_or_inf
+        # Forward vs reverse should agree to around 1e-6 or better
+        assert report.rel_err_fwd_rev is not None
+        assert report.rel_err_fwd_rev < 1e-5
+        # Autograd vs numerical should agree to around 1e-2 on this toy model
+        assert report.rel_err_autodiff_num is not None
+        assert report.rel_err_autodiff_num < 1e-2


### PR DESCRIPTION
### Differentiation Tools

### Summary

This PR introduces a complete differentiability-testing stack to MacroStat:

- A new `macrostat.diff` module for computing Jacobians via PyTorch’s `torch.func` API and validating them against numerical finite differences.
- A simple analytic test model `LINEAR2D` used as a ground-truth benchmark.
- Unit tests tying the diff tools to `LINEAR2D`.
- Documentation and example scripts that demonstrate how to use these tools and how to check differentiability on larger models.

Closes #34
Closes #35
Closes #38 

---

### Core changes

#### 1. `macrostat.diff`: autodiff and numerical Jacobians

New module providing:

- `JacobianBase`
  - Holds a `Model` and `scenario`.
  - Builds a training `Behavior` via `model.get_model_training_instance(...)`.
  - Extracts parameters as a `dict[str, Tensor]` from `behavior.named_parameters()`, filtered to names starting with `params.` (parameters only).

- `JacobianAutograd`
  - Uses `torch.func.functional_call`, `jacrev`, and `jacfwd` to compute Jacobians of a scalar loss w.r.t. model parameters.
  - API:
    ```python
    from macrostat.diff import JacobianAutograd

    jac = JacobianAutograd(model, scenario=0)
    grads_rev = jac.compute(loss_fn=loss_fn, mode="rev")  # or "fwd"
    ```
  - `loss_fn(output: dict[str, Tensor]) -> scalar Tensor`; returns `dict[param_name -> grad Tensor]`.

- `JacobianNumerical`
  - Finite-difference Jacobian using the same parameter dict and `torch.func.functional_call`:
    ```python
    from macrostat.diff import JacobianNumerical

    jac_num = JacobianNumerical(model, scenario=0, epsilon=1e-5)
    grads_num = jac_num.compute(loss_fn=loss_fn, mode="central")  # or "forward"/"backward"
    ```
  - Also expects a scalar loss; returns `dict[param_name -> grad Tensor]`.

- `DifferentiabilityReport` & `check_model_differentiability`
  - `check_model_differentiability(model, loss_fn, ...)`:
    - Computes reverse-mode autograd gradients as baseline.
    - Optionally compares them to forward-mode autograd and numerical finite differences.
  - `DifferentiabilityReport` exposes:
    - `nan_or_inf` – any NaNs/Infs in gradients.
    - `max_abs_diff_fwd_rev`, `rel_err_fwd_rev` – absolute & relative discrepancies between forward and reverse autograd.
    - `max_abs_diff_autodiff_num`, `rel_err_autodiff_num` – absolute & relative discrepancies between autograd and numerical gradients.
    - `details` – per-parameter/per-comparison diagnostics.

This design encourages interpreting “how accurate” gradients are (e.g. “accurate up to ~1e‑3 relative error”) rather than a binary pass/fail.

---

#### 2. LINEAR2D: analytic test model

New model under `src/macrostat/models/LINEAR2D/`:

- **Parameters** (`ParametersLINEAR2D`)
  - `a11, a12, a21, a22` – entries of a 2×2 matrix `A`.
  - `x0_1, x0_2` – initial state `x₀`.
  - Default bounds: `[-10, 10]`.
  - Hyperparameters: small horizon (`timesteps=5`, `timesteps_initialization=0`), simple sector metadata.

- **Variables** (`VariablesLINEAR2D`)
  - Single variable `State` (notation `x(t)`), holding a `(timesteps, 2)` tensor.

- **Scenarios** (`ScenariosLINEAR2D`)
  - No exogenous shocks; default scenario is an empty dict.
  - Present to satisfy the standard MacroStat model interface.

- **Behavior** (`BehaviorLINEAR2D`)
  - Follows the standard `Behavior` pattern (no custom `forward` override):
    - `initialize()`: sets `self.state["State"] = [x0_1, x0_2]`.
    - `step(t, scenario, params)`: computes `x_{t+1} = A x_t` using `self.prior["State"]`.
  - The base `Behavior.forward` handles seeding, history, scenarios, and recording.

- **Model wrapper** (`LINEAR2D`)
  - `Model` subclass wiring `ParametersLINEAR2D`, `VariablesLINEAR2D`, `ScenariosLINEAR2D`, and `BehaviorLINEAR2D`.

Because the dynamics are

$$
x_{t+1} = A x_t,
$$

with `A` and `x₀` fully parameterised, the Jacobian of a simple loss on `x_T` can be written down analytically. This makes `LINEAR2D` a good validation model for the new diff tools.

---

#### 3. Behavior robustness: parameter shocks without `vector_sectors`

In `src/macrostat/core/behavior.py`, `apply_parameter_shocks` previously assumed `self.hyper["vector_sectors"]` always existed, which caused:

- `KeyError` in models/hyperparameter settings that don’t define `vector_sectors`.
- Failures in `tests/core/behavior_test.py::TestBehavior::test_apply_parameter_shocks_*`.
- “Default simulation is healthy” tests to fail in some models.

Now:

- Uses:
  ```python
  vsecs = self.hyper.get("vector_sectors", [])
  ```
- Only builds sector vectors/matrices if `len(vsecs) > 0`.
- Otherwise falls back to simple element-wise multiplicative/additive shocks.

This preserves the intended semantics in the tests (no shocks returns original parameters; multiplicative/additive shocks behave as specified) and keeps existing models healthy.

---

### Tests

New tests:

- **`tests/diff/diff_test.py`**
  - `test_autograd_vs_numerical_close`:
    - Instantiates `LINEAR2D`.
    - Defines `loss_fn` on the final `State` vs `[1, 0]`.
    - Compares autograd vs numerical gradients parameterwise; asserts max relative error `< 1e‑2`.
  - `test_checker_reports_small_relative_errors`:
    - Runs `check_model_differentiability` on `LINEAR2D`.
    - Asserts:
      - No NaNs/Infs.
      - `rel_err_fwd_rev` is very small (~1e‑5 or better) for forward vs reverse autograd.
      - `rel_err_autodiff_num` is within a modest threshold (~1e‑2) for autograd vs numerical.

All existing tests continue to pass. Verified with:

```bash
cd /home/karl/Dropbox/workspace/github.com/KarlNaumann/MacroStat
uv run pytest
```

---

### Documentation

#### Diff user guide

- **`docs/user_guide/diff.rst`**
  - Introduces `macrostat.diff`, with code snippets showing:
    - How to use `JacobianAutograd` and `JacobianNumerical`.
    - How to call `check_model_differentiability` and read `DifferentiabilityReport`.
  - Describes `rel_err_fwd_rev` and `rel_err_autodiff_num` as measures of how accurate gradients are.
  - Uses simple wording (“2D state vector”, “2×2 matrix”) instead of fragile `\mathbb` macros.

#### Testing models: LINEAR2D

- **Model library nav (`docs/models/index.rst`)**
  - Adds a “Testing models” entry alongside ECO3IOPC, GL06, IOPC, and NK3E.

---

### How to use (example)

```python
import torch
from macrostat.models import get_model
from macrostat.diff import (
    JacobianAutograd,
    JacobianNumerical,
    check_model_differentiability,
)

# Build test model
ModelClass = get_model("LINEAR2D")
model = ModelClass()

target = torch.tensor([1.0, 0.0])

def loss_fn(output: dict[str, torch.Tensor]) -> torch.Tensor:
    y = output["State"][-1]  # final state (2,)
    return torch.nn.functional.mse_loss(y, target)

# Autograd-based Jacobian
jac_auto = JacobianAutograd(model)
grads_rev = jac_auto.compute(loss_fn=loss_fn, mode="rev")

# Numerical Jacobian
jac_num = JacobianNumerical(model, epsilon=1e-5)
grads_num = jac_num.compute(loss_fn=loss_fn, mode="central")

# High-level consistency check
report = check_model_differentiability(
    model,
    loss_fn,
    scenario=0,
    rtol=1e-5,
    atol=1e-8,
    compare_forward_reverse=True,
    compare_numerical=True,
    numerical_mode="central",
    epsilon=1e-5,
)
print(report.summary())
```

This pattern is also used in the offline example scripts for GL06SIMEX and NK3E, and in the EIRIN calibration checker, to quickly assess differentiability quality before running more expensive calibration routines.