### PR TITLE
feat(core): LinearConstraint system with vector/matrix resolver

### DIFF
--- a/docs/models/GL06/GL06INSOUT.ipynb
+++ b/docs/models/GL06/GL06INSOUT.ipynb
@@ -361,6 +361,27 @@
   },
   {
    "cell_type": "markdown",
+   "id": "constraints-pointer",
+   "metadata": {},
+   "source": [
+    "### Tobin portfolio constraints\n",
+    "\n",
+    "The 20 portfolio $\\lambda$ coefficients are not all independent. ",
+    "Godley-Lavoie's adding-up identities require the four constants to ",
+    "sum to one and each rate-sensitivity column to sum to zero, for a ",
+    "total of five linear constraints. GL06INSOUT declares these via ",
+    "the `LinearConstraint` system in its `Parameters.get_constraints` ",
+    "method, with M1 cash as the residual asset in every group. The ",
+    "five M1 coefficients are therefore *derived* parameters: their ",
+    "values are computed from the other 15, and autograd reports a ",
+    "zero gradient for them. ",
+    "See the [Constraints user guide](../../user_guide/core/constraints.rst) ",
+    "and the [worked example notebook](../../user_guide/constraints_example.ipynb) ",
+    "for details."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "8195da80",
    "metadata": {},
    "source": [

--- a/docs/user_guide/_doc_helpers.py
+++ b/docs/user_guide/_doc_helpers.py
@@ -1,0 +1,42 @@
+# Copyright (c) 2025 Karl Naumann-Woleske
+# Author: Karl Naumann-Woleske <karl@naumannwoleske.com>
+# SPDX-License-Identifier: MIT
+
+"""Top-level loss functions used by the user-guide example notebooks.
+
+These functions live in a module (rather than inline in the notebooks)
+because :class:`macrostat.diff.JacobianNumerical` runs its
+finite-difference passes through ``multiprocessing`` with the ``spawn``
+start method, which requires worker callables to be importable from a
+module rather than defined in ``__main__`` (the notebook scope).
+"""
+
+import torch
+
+
+def mean_nominal_output(output: dict[str, torch.Tensor]) -> torch.Tensor:
+    """Mean of ``NominalOutput`` across timesteps.
+
+    Used as a generic scalar loss for GL06INSOUT and later GL06 variants in
+    the user-guide notebooks. Picks a single observable so that the example
+    output stays interpretable.
+    """
+    return output["NominalOutput"].mean()
+
+
+def mean_national_income(output: dict[str, torch.Tensor]) -> torch.Tensor:
+    """Mean of ``NationalIncome`` across timesteps.
+
+    Used as the scalar loss for GL06SIMEX in the diagnostics notebook, which
+    exposes national income rather than nominal output.
+    """
+    return output["NationalIncome"].mean()
+
+
+def final_state_norm(output: dict[str, torch.Tensor]) -> torch.Tensor:
+    """L2 norm of the final state vector for LINEAR2D.
+
+    Used by the diagnostics notebook to demonstrate direct-space
+    finite differences on a model with a zero parameter.
+    """
+    return output["State"][-1].pow(2).sum().sqrt()

--- a/docs/user_guide/constraints_example.ipynb
+++ b/docs/user_guide/constraints_example.ipynb
@@ -251,7 +251,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "id": "autograd-code",
    "metadata": {
     "execution": {
@@ -261,43 +261,8 @@
      "shell.execute_reply": "2026-04-10T07:49:35.537929Z"
     }
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  d(loss)/d(share_a) = -2.000\n",
-      "  d(loss)/d(share_b) = -1.000\n",
-      "  share_c is derived: is_leaf=False, requires_grad=True\n"
-     ]
-    }
-   ],
-   "source": [
-    "p = ToyParameters()\n",
-    "\n",
-    "# Build leaf tensors for the FREE parameters; the residual is then\n",
-    "# derived from them so it is not a leaf and has no gradient of its own.\n",
-    "free_names = ('share_a', 'share_b')\n",
-    "tensors = {\n",
-    "    name: torch.tensor(p.values[name]['value'], requires_grad=True)\n",
-    "    for name in free_names\n",
-    "}\n",
-    "for c in p.get_constraints():\n",
-    "    c.enforce(tensors)  # writes share_c = 1 - share_a - share_b\n",
-    "\n",
-    "loss = (\n",
-    "    2.0 * tensors['share_a']\n",
-    "    + 3.0 * tensors['share_b']\n",
-    "    + 4.0 * tensors['share_c']\n",
-    ")\n",
-    "loss.backward()\n",
-    "\n",
-    "for name in ('share_a', 'share_b'):\n",
-    "    print(f'  d(loss)/d({name}) = {tensors[name].grad.item():+.3f}')\n",
-    "share_c = tensors['share_c']\n",
-    "print(f'  share_c is derived: is_leaf={share_c.is_leaf}, '\n",
-    "      f'requires_grad={share_c.requires_grad}')"
-   ]
+   "outputs": [],
+   "source": "p = ToyParameters()\n\n# Build leaf tensors for the FREE parameters; the residual is then\n# derived from them so it is not a leaf and has no gradient of its own.\n# Initialise the residual slot as a zero placeholder of the same dtype;\n# LinearConstraint.apply will overwrite it through the resolver.\nfree_names = ('share_a', 'share_b')\ntensors = {\n    name: torch.tensor(p.values[name]['value'], requires_grad=True)\n    for name in free_names\n}\ntensors['share_c'] = torch.tensor(0.0)\n\n# The step-time apply() path wants a ConstraintResolver. Build one\n# against the Parameters instance; for this scalar toy model every\n# slot resolves to its own tensor key with no index.\nresolver = p.get_constraint_resolver()\nfor c in p.get_constraints():\n    c.apply(tensors, resolver)  # writes share_c = 1 - share_a - share_b\n\nloss = (\n    2.0 * tensors['share_a']\n    + 3.0 * tensors['share_b']\n    + 4.0 * tensors['share_c']\n)\nloss.backward()\n\nfor name in ('share_a', 'share_b'):\n    print(f'  d(loss)/d({name}) = {tensors[name].grad.item():+.3f}')\nshare_c = tensors['share_c']\nprint(f'  share_c is derived: is_leaf={share_c.is_leaf}, '\n      f'requires_grad={share_c.requires_grad}')"
   },
   {
    "cell_type": "markdown",
@@ -443,7 +408,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "6fd1a8ce",
+   "id": "real-jacobians-interp",
    "metadata": {},
    "source": "`TaxRate` agrees to four significant digits. The two unrelated parameters and `WealthShareBonds_Constant` agree to roughly 1%; the two other Tobin constants show disagreements of 6% and 21%. This residual disagreement is *not* a constraint-system bug. GL06INSOUT's `portfolio_switches` method uses a step-function `torch.where` to select between the M1- and M2-dominated regimes, and any parameter that moves the economy near that boundary (which the Tobin constants do by shifting the baseline portfolio composition) straddles the discontinuity under finite differences. Autograd reports zero gradient at the switch; numerical differences see a finite jump. See the \"Expected disagreements\" section of [Differentiability and Jacobian Tools](diff.rst) and the worked example in [Jacobian Diagnostics](jacobian_diagnostics.ipynb).\n\nThe next cell runs the check that *is* the constraint-system guarantee: every derived M1 parameter should have exactly zero autograd gradient."
   },
@@ -484,14 +449,7 @@
    "cell_type": "markdown",
    "id": "closing",
    "metadata": {},
-   "source": [
-    "## Closing notes\n",
-    "\n",
-    "* The constraint system is opt-in: existing models that do not override `get_constraints` are unaffected.\n",
-    "* The same `LinearConstraint.enforce` runs at parameter init and inside `Behavior.apply_parameter_shocks`, so scenario shocks to free parameters automatically propagate to the residual.\n",
-    "* For the API and the verification rules, see [Constraints](core/constraints.rst).\n",
-    "* For diagnosing autograd vs numerical disagreements that are *not* explained by constraints, see [Jacobian Diagnostics](jacobian_diagnostics.ipynb)."
-   ]
+   "source": "## Closing notes\n\n* The constraint system is opt-in: existing models that do not override `get_constraints` are unaffected.\n* `LinearConstraint.apply` runs inside `Behavior.apply_parameter_shocks` at every step, fetched fresh against the current `Parameters` instance, so scenario shocks to free parameters automatically propagate to the residual. The init-time adjustment happens via `Parameters.enforce_constraints`.\n* For the API and the verification rules, see [Constraints](core/constraints.rst).\n* For diagnosing autograd vs numerical disagreements that are *not* explained by constraints, see [Jacobian Diagnostics](jacobian_diagnostics.ipynb)."
   }
  ],
  "metadata": {

--- a/docs/user_guide/constraints_example.ipynb
+++ b/docs/user_guide/constraints_example.ipynb
@@ -1,0 +1,518 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "intro",
+   "metadata": {},
+   "source": [
+    "# Parameter constraints with `LinearConstraint`\n",
+    "\n",
+    "This notebook is a runnable companion to the [Constraints user guide](core/constraints.rst). It shows how to declare a `LinearConstraint`, what `verify_constraints` and `enforce_constraints` actually do, and how the residual parameterization shows up in autograd Jacobians. The final section uses the production GL06INSOUT model to confirm that the constraint system makes every derived M1 parameter invisible to autograd, and discusses how to read the numerical Jacobian comparison on the free parameters."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "version",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-10T07:49:34.649075Z",
+     "iopub.status.busy": "2026-04-10T07:49:34.648981Z",
+     "iopub.status.idle": "2026-04-10T07:49:35.413578Z",
+     "shell.execute_reply": "2026-04-10T07:49:35.413241Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "macrostat version: 0.5.7.post1.dev7+g35c4d7655.d20260409\n",
+      "torch version:     2.11.0+cu130\n"
+     ]
+    }
+   ],
+   "source": [
+    "import macrostat\n",
+    "import torch\n",
+    "\n",
+    "print('macrostat version:', macrostat.__version__)\n",
+    "print('torch version:    ', torch.__version__)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "minimal-model",
+   "metadata": {},
+   "source": [
+    "## A minimal Parameters subclass\n",
+    "\n",
+    "The smallest demonstration is a three-parameter group whose values must sum to one. We pick the third parameter as the residual."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "minimal-code",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-10T07:49:35.414685Z",
+     "iopub.status.busy": "2026-04-10T07:49:35.414534Z",
+     "iopub.status.idle": "2026-04-10T07:49:35.523523Z",
+     "shell.execute_reply": "2026-04-10T07:49:35.522981Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "from macrostat.core.parameters import Parameters\n",
+    "from macrostat.core.constraints import LinearConstraint\n",
+    "\n",
+    "\n",
+    "class ToyParameters(Parameters):\n",
+    "    def get_default_parameters(self):\n",
+    "        return {\n",
+    "            'share_a': {'value': 0.4, 'lower bound': 0.0,\n",
+    "                        'upper bound': 1.0, 'notation': 'a', 'unit': '.'},\n",
+    "            'share_b': {'value': 0.3, 'lower bound': 0.0,\n",
+    "                        'upper bound': 1.0, 'notation': 'b', 'unit': '.'},\n",
+    "            'share_c': {'value': 0.3, 'lower bound': 0.0,\n",
+    "                        'upper bound': 1.0, 'notation': 'c', 'unit': '.'},\n",
+    "        }\n",
+    "\n",
+    "    def get_constraints(self):\n",
+    "        return (\n",
+    "            LinearConstraint(\n",
+    "                param_names=('share_a', 'share_b', 'share_c'),\n",
+    "                target=1.0,\n",
+    "            ),\n",
+    "        )"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "failing-case",
+   "metadata": {},
+   "source": [
+    "## What happens when defaults violate the constraint?\n",
+    "\n",
+    "Before the success case, deliberately give the toy parameters a set of defaults that do not sum to the target. The verifier emits a warning at construction time, and `enforce_constraints` then adjusts the residual parameter so the identity holds."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "failing-code",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-10T07:49:35.524707Z",
+     "iopub.status.busy": "2026-04-10T07:49:35.524550Z",
+     "iopub.status.idle": "2026-04-10T07:49:35.528041Z",
+     "shell.execute_reply": "2026-04-10T07:49:35.527776Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "WARNING:macrostat.core.parameters:Constraint violation in defaults: sum(('share_a', 'share_b', 'share_c')) = 0.90000000, target = 1.00000000. Derived parameter 'share_c' will be adjusted.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "after init:\n",
+      "  share_a = 0.5\n",
+      "  share_b = 0.3\n",
+      "  share_c = 0.19999999999999996\n",
+      "sum = 1.0\n"
+     ]
+    }
+   ],
+   "source": [
+    "import logging\n",
+    "logging.basicConfig(level=logging.WARNING, force=True)\n",
+    "\n",
+    "class ViolatingToy(ToyParameters):\n",
+    "    def get_default_parameters(self):\n",
+    "        defaults = super().get_default_parameters()\n",
+    "        # These sum to 0.9, not 1.0\n",
+    "        defaults['share_a']['value'] = 0.5\n",
+    "        defaults['share_b']['value'] = 0.3\n",
+    "        defaults['share_c']['value'] = 0.1\n",
+    "        return defaults\n",
+    "\n",
+    "p_bad = ViolatingToy()\n",
+    "print('after init:')\n",
+    "for k in ('share_a', 'share_b', 'share_c'):\n",
+    "    print(f'  {k} = {p_bad.values[k][\"value\"]}')\n",
+    "print('sum =', sum(p_bad.values[k]['value'] for k in\n",
+    "                  ('share_a', 'share_b', 'share_c')))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "explain-fix",
+   "metadata": {},
+   "source": [
+    "The warning fired during construction; the residual `share_c` was then overwritten from `0.1` to `0.2` so the group sums to `1.0`. The free parameters `share_a` and `share_b` were left untouched."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "happy-path",
+   "metadata": {},
+   "source": [
+    "## The happy path: free parameters move, derived parameter follows\n",
+    "\n",
+    "Now use the consistent defaults from `ToyParameters`. Mutate one of the free parameters and re-run `enforce_constraints` to see the residual track."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "happy-code",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-10T07:49:35.529023Z",
+     "iopub.status.busy": "2026-04-10T07:49:35.528937Z",
+     "iopub.status.idle": "2026-04-10T07:49:35.531126Z",
+     "shell.execute_reply": "2026-04-10T07:49:35.530838Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "initial values:\n",
+      "  share_a = 0.4\n",
+      "  share_b = 0.3\n",
+      "  share_c = 0.30000000000000004\n",
+      "\n",
+      "after share_a := 0.55 and enforce_constraints():\n",
+      "  share_a = 0.55\n",
+      "  share_b = 0.3\n",
+      "  share_c = 0.1499999999999999\n"
+     ]
+    }
+   ],
+   "source": [
+    "p = ToyParameters()\n",
+    "print('initial values:')\n",
+    "for k in ('share_a', 'share_b', 'share_c'):\n",
+    "    print(f'  {k} = {p.values[k][\"value\"]}')\n",
+    "\n",
+    "p.values['share_a']['value'] = 0.55\n",
+    "p.enforce_constraints()\n",
+    "print()\n",
+    "print('after share_a := 0.55 and enforce_constraints():')\n",
+    "for k in ('share_a', 'share_b', 'share_c'):\n",
+    "    print(f'  {k} = {p.values[k][\"value\"]}')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "free-names",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-10T07:49:35.532007Z",
+     "iopub.status.busy": "2026-04-10T07:49:35.531925Z",
+     "iopub.status.idle": "2026-04-10T07:49:35.533641Z",
+     "shell.execute_reply": "2026-04-10T07:49:35.533345Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "all parameters: ['share_a', 'share_b', 'share_c']\n",
+      "free parameters: ['share_a', 'share_b']\n"
+     ]
+    }
+   ],
+   "source": [
+    "print('all parameters:', list(p.values.keys()))\n",
+    "print('free parameters:', p.get_free_param_names())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "autograd-section",
+   "metadata": {},
+   "source": [
+    "## Autograd consequence: derived parameter has zero gradient\n",
+    "\n",
+    "Because `share_c = 1 - share_a - share_b` is encoded as a tensor operation, autograd never treats `share_c` as a free leaf. Any downstream loss has zero gradient with respect to it; the sensitivity is absorbed into `share_a` and `share_b`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "autograd-code",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-10T07:49:35.534475Z",
+     "iopub.status.busy": "2026-04-10T07:49:35.534370Z",
+     "iopub.status.idle": "2026-04-10T07:49:35.538342Z",
+     "shell.execute_reply": "2026-04-10T07:49:35.537929Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  d(loss)/d(share_a) = -2.000\n",
+      "  d(loss)/d(share_b) = -1.000\n",
+      "  share_c is derived: is_leaf=False, requires_grad=True\n"
+     ]
+    }
+   ],
+   "source": [
+    "p = ToyParameters()\n",
+    "\n",
+    "# Build leaf tensors for the FREE parameters; the residual is then\n",
+    "# derived from them so it is not a leaf and has no gradient of its own.\n",
+    "free_names = ('share_a', 'share_b')\n",
+    "tensors = {\n",
+    "    name: torch.tensor(p.values[name]['value'], requires_grad=True)\n",
+    "    for name in free_names\n",
+    "}\n",
+    "for c in p.get_constraints():\n",
+    "    c.enforce(tensors)  # writes share_c = 1 - share_a - share_b\n",
+    "\n",
+    "loss = (\n",
+    "    2.0 * tensors['share_a']\n",
+    "    + 3.0 * tensors['share_b']\n",
+    "    + 4.0 * tensors['share_c']\n",
+    ")\n",
+    "loss.backward()\n",
+    "\n",
+    "for name in ('share_a', 'share_b'):\n",
+    "    print(f'  d(loss)/d({name}) = {tensors[name].grad.item():+.3f}')\n",
+    "share_c = tensors['share_c']\n",
+    "print(f'  share_c is derived: is_leaf={share_c.is_leaf}, '\n",
+    "      f'requires_grad={share_c.requires_grad}')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "explain-autograd",
+   "metadata": {},
+   "source": [
+    "The free parameters report `2 - 4 = -2` and `3 - 4 = -1` because the residual coefficient `4` flows back through `share_c = 1 - share_a - share_b` with `d(share_c)/d(share_a) = -1`. The derived parameter `share_c` is a function of the leaves and so has no gradient of its own. This is the residual parameterization in action."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "real-section",
+   "metadata": {},
+   "source": [
+    "## Real-world example: GL06INSOUT\n",
+    "\n",
+    "The Godley-Lavoie INSOUT model has a 4-asset Tobin portfolio with M1 cash as the buffer-stock residual. Five `LinearConstraint` instances cover the constants and the four rate-sensitivity columns.\n",
+    "\n",
+    "The constraint system's guarantee is narrow and mechanical: every derived M1 parameter is a tensor function of the free parameters, not a leaf, so autograd sees *exactly* zero sensitivity with respect to it. We check that first. Numerical-vs-autograd agreement on the *free* parameters is a separate question that depends on the rest of the model's numerical behaviour, which we discuss after the comparison."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "real-load",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-10T07:49:35.539727Z",
+     "iopub.status.busy": "2026-04-10T07:49:35.539571Z",
+     "iopub.status.idle": "2026-04-10T07:49:35.546510Z",
+     "shell.execute_reply": "2026-04-10T07:49:35.546142Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "GL06INSOUT declares 5 constraints:\n",
+      "  1. target=1.0\n",
+      "     free   : ['WealthShareM2_Constant', 'WealthShareBills_Constant', 'WealthShareBonds_Constant']\n",
+      "     derived: WealthShareM1_Constant\n",
+      "  2. target=0.0\n",
+      "     free   : ['WealthShareM2_DepositRate', 'WealthShareBills_DepositRate', 'WealthShareBonds_DepositRate']\n",
+      "     derived: WealthShareM1_DepositRate\n",
+      "  3. target=0.0\n",
+      "     free   : ['WealthShareM2_BillRate', 'WealthShareBills_BillRate', 'WealthShareBonds_BillRate']\n",
+      "     derived: WealthShareM1_BillRate\n",
+      "  4. target=0.0\n",
+      "     free   : ['WealthShareM2_BondYield', 'WealthShareBills_BondYield', 'WealthShareBonds_BondYield']\n",
+      "     derived: WealthShareM1_BondYield\n",
+      "  5. target=0.0\n",
+      "     free   : ['WealthShareM2_Income', 'WealthShareBills_Income', 'WealthShareBonds_Income']\n",
+      "     derived: WealthShareM1_Income\n"
+     ]
+    }
+   ],
+   "source": [
+    "from macrostat.models import get_model\n",
+    "\n",
+    "model = get_model('GL06INSOUT')()\n",
+    "constraints = model.parameters.get_constraints()\n",
+    "print(f'GL06INSOUT declares {len(constraints)} constraints:')\n",
+    "for i, c in enumerate(constraints, 1):\n",
+    "    print(f'  {i}. target={c.target}')\n",
+    "    print(f'     free   : {list(c.free_params)}')\n",
+    "    print(f'     derived: {c.derived_param}')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "real-jacobians",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-10T07:49:35.547536Z",
+     "iopub.status.busy": "2026-04-10T07:49:35.547443Z",
+     "iopub.status.idle": "2026-04-10T07:49:42.098196Z",
+     "shell.execute_reply": "2026-04-10T07:49:42.097842Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Jacobian comparison: autograd vs numerical (log, eps=1e-3)\n",
+      "Parameters compared: 5\n",
+      "Overall max abs diff: 1.899e+00  max rel diff: 2.077e-01\n",
+      "\n",
+      "Parameter                                   max_abs   mean_abs    max_rel   mean_rel        close nan/inf\n",
+      "---------------------------------------------------------------------------------------------------------\n",
+      "WealthShareBills_Constant                 1.899e+00  1.899e+00  2.077e-01  2.077e-01          0/1      no\n",
+      "WealthShareM2_Constant                    5.841e-02  5.841e-02  5.841e-02  5.841e-02          0/1      no\n",
+      "WealthShareBonds_Constant                 1.534e-01  1.534e-01  7.729e-03  7.729e-03          0/1      no\n",
+      "InventorySalesRatioBaseline               9.693e-02  9.693e-02  3.941e-03  3.941e-03          0/1      no\n",
+      "TaxRate                                   3.356e-01  3.356e-01  1.868e-04  1.868e-04          1/1      no\n"
+     ]
+    }
+   ],
+   "source": [
+    "import sys, os\n",
+    "# Make the doc helper module importable from the notebook\n",
+    "sys.path.insert(0, os.path.abspath('.'))\n",
+    "from _doc_helpers import mean_nominal_output\n",
+    "\n",
+    "from macrostat.diff import (\n",
+    "    JacobianAutograd,\n",
+    "    JacobianNumerical,\n",
+    "    compare_jacobian_dicts,\n",
+    ")\n",
+    "\n",
+    "# Hand-picked subset: a few free parameters from the Tobin matrix\n",
+    "# (where the constraint system matters) plus two unrelated parameters\n",
+    "# as a sanity check. A full sweep over all 42 free parameters takes\n",
+    "# minutes; for a worked example, five is enough to demonstrate the\n",
+    "# pattern.\n",
+    "sample_params = [\n",
+    "    'WealthShareM2_Constant',\n",
+    "    'WealthShareBills_Constant',\n",
+    "    'WealthShareBonds_Constant',\n",
+    "    'TaxRate',\n",
+    "    'InventorySalesRatioBaseline',\n",
+    "]\n",
+    "\n",
+    "jac_auto = JacobianAutograd(model).compute(\n",
+    "    loss_fn=mean_nominal_output, mode='rev',\n",
+    ")\n",
+    "jac_num = JacobianNumerical(model).compute(\n",
+    "    loss_fn=mean_nominal_output, mode='central', num_workers=1,\n",
+    "    param_names=sample_params,\n",
+    ")\n",
+    "\n",
+    "jac_auto_subset = {k: jac_auto[k] for k in sample_params}\n",
+    "\n",
+    "report = compare_jacobian_dicts(\n",
+    "    jac_auto_subset, jac_num,\n",
+    "    method_a='autograd', method_b='numerical (log, eps=1e-3)',\n",
+    "    rtol=1e-3, atol=1e-6,\n",
+    ")\n",
+    "print(report.summary())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6fd1a8ce",
+   "metadata": {},
+   "source": "`TaxRate` agrees to four significant digits. The two unrelated parameters and `WealthShareBonds_Constant` agree to roughly 1%; the two other Tobin constants show disagreements of 6% and 21%. This residual disagreement is *not* a constraint-system bug. GL06INSOUT's `portfolio_switches` method uses a step-function `torch.where` to select between the M1- and M2-dominated regimes, and any parameter that moves the economy near that boundary (which the Tobin constants do by shifting the baseline portfolio composition) straddles the discontinuity under finite differences. Autograd reports zero gradient at the switch; numerical differences see a finite jump. See the \"Expected disagreements\" section of [Differentiability and Jacobian Tools](diff.rst) and the worked example in [Jacobian Diagnostics](jacobian_diagnostics.ipynb).\n\nThe next cell runs the check that *is* the constraint-system guarantee: every derived M1 parameter should have exactly zero autograd gradient."
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "derived-zero",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-10T07:49:42.099320Z",
+     "iopub.status.busy": "2026-04-10T07:49:42.099173Z",
+     "iopub.status.idle": "2026-04-10T07:49:42.101310Z",
+     "shell.execute_reply": "2026-04-10T07:49:42.101030Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  WealthShareM1_Constant              max|grad| = 0.000e+00\n",
+      "  WealthShareM1_DepositRate           max|grad| = 0.000e+00\n",
+      "  WealthShareM1_BillRate              max|grad| = 0.000e+00\n",
+      "  WealthShareM1_BondYield             max|grad| = 0.000e+00\n",
+      "  WealthShareM1_Income                max|grad| = 0.000e+00\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Confirm that every derived M1 parameter has exactly zero autograd gradient\n",
+    "derived = [c.derived_param for c in constraints]\n",
+    "for name in derived:\n",
+    "    g = jac_auto[name]\n",
+    "    print(f'  {name:<35s} max|grad| = {g.abs().max().item():.3e}')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "closing",
+   "metadata": {},
+   "source": [
+    "## Closing notes\n",
+    "\n",
+    "* The constraint system is opt-in: existing models that do not override `get_constraints` are unaffected.\n",
+    "* The same `LinearConstraint.enforce` runs at parameter init and inside `Behavior.apply_parameter_shocks`, so scenario shocks to free parameters automatically propagate to the residual.\n",
+    "* For the API and the verification rules, see [Constraints](core/constraints.rst).\n",
+    "* For diagnosing autograd vs numerical disagreements that are *not* explained by constraints, see [Jacobian Diagnostics](jacobian_diagnostics.ipynb)."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.13.5"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/user_guide/core/behavior.rst
+++ b/docs/user_guide/core/behavior.rst
@@ -30,6 +30,18 @@ Differentiable Operations
    Behavior.diffmin_v
    Behavior.diffmax_v
 
+Parameter shocks and constraints
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+During every simulation step, :meth:`Behavior.apply_parameter_shocks`
+applies any active scenario shocks to the parameter tensors and then
+re-runs every :class:`~macrostat.core.constraints.LinearConstraint`
+returned by the model's parameters. This second pass keeps adding-up
+identities intact when scenarios shock free parameters in a
+constrained group, and the operation is differentiable so both
+autograd and finite-difference Jacobians see the residual relationship
+at every timestep. See :doc:`constraints` for details.
+
 Notes
 ~~~~~
 The Behavior class is designed to be a flexible base class that allows users to implement their own model behavior while maintaining a consistent interface. The key methods that users need to implement are `initialize()` and `step()`, which define the model's initialization and simulation behavior respectively.

--- a/docs/user_guide/core/constraints.rst
+++ b/docs/user_guide/core/constraints.rst
@@ -11,11 +11,14 @@ a model declare these relationships once, and MacroStat enforces them
 both at parameter initialization and inside every simulation step,
 without breaking autograd.
 
-Constructor
-~~~~~~~~~~~
+Public API
+~~~~~~~~~~
 .. autosummary::
 
+   ConstraintError
    LinearConstraint
+   ParameterLocation
+   ConstraintResolver
 
 Properties and methods
 ~~~~~~~~~~~~~~~~~~~~~~
@@ -23,7 +26,10 @@ Properties and methods
 
    LinearConstraint.free_params
    LinearConstraint.derived_param
-   LinearConstraint.enforce
+   LinearConstraint.apply
+   ParameterLocation.read
+   ParameterLocation.write
+   ConstraintResolver.locate
 
 
 Residual parameterization
@@ -82,11 +88,76 @@ Each :class:`LinearConstraint` accepts:
   before it is free.
 * ``target`` (``float``): the value the group must sum to.
 
-The order of constraints in the returned tuple is preserved. If a
-parameter is the derived parameter in one constraint and a free
-parameter in another, MacroStat does not topologically reorder for
-you. The user is responsible for ordering such that each constraint
-is well-defined when it runs.
+Constraints are applied in declaration order. Chaining — where the
+derived parameter of one constraint appears as a free parameter in
+another — is explicitly rejected by
+:meth:`~macrostat.core.parameters.Parameters.verify_constraints`
+and will raise :class:`ConstraintError` at init time. If you need
+cascading relationships, collapse them into a single constraint or
+restructure the parameter group.
+
+
+Vector and matrix constraints
+=============================
+
+A constraint does not need to live at the scalar layer. Parameters
+that follow the sectoral naming convention ``sector.name`` or
+``rowsec.colsec.name`` are vectorised by
+:meth:`~macrostat.core.parameters.Parameters.vectorize_parameters`
+into 1-D or 2-D tensors at step time, and the same
+:class:`LinearConstraint` can enforce an adding-up identity across
+those tensor slots.
+
+The seam that makes this work is the
+:class:`ConstraintResolver`. At step time, each constraint asks the
+resolver to map its canonical parameter names to
+:class:`ParameterLocation` records: a ``(tensor_key, index)`` pair
+that says where the parameter lives inside the step-time tensor
+dictionary. Scalar parameters resolve to ``index=None``; sector-
+indexed parameters resolve to ``index=(i,)``; sector-by-sector
+parameters resolve to ``index=(i, j)``. :meth:`LinearConstraint.apply`
+reads the free slots, computes ``target - sum(free)``, and writes
+the residual into the derived slot via
+:func:`torch.Tensor.index_put`, which is out-of-place and
+differentiable.
+
+As an example, consider a two-sector household share that must sum
+to one:
+
+.. code-block:: python
+
+   from macrostat.core import LinearConstraint, Parameters
+
+   class HouseholdShares(Parameters):
+       def get_default_parameters(self):
+           return {
+               "Household.Share": {"value": 0.6, ...},
+               "Firm.Share":      {"value": 0.4, ...},
+           }
+
+       def get_default_hyperparameters(self):
+           h = super().get_default_hyperparameters()
+           h["vector_sectors"] = ["Household", "Firm"]
+           return h
+
+       def get_constraints(self):
+           return (
+               LinearConstraint(
+                   param_names=("Household.Share", "Firm.Share"),
+                   target=1.0,
+               ),
+           )
+
+When the model initialises, the resolver is built lazily by
+:meth:`~macrostat.core.parameters.Parameters.get_constraint_resolver`
+and cached on the :class:`~macrostat.core.parameters.Parameters`
+instance. At step time,
+:meth:`~macrostat.core.behavior.Behavior.apply_parameter_shocks`
+calls :meth:`LinearConstraint.apply` with that resolver. All
+parameters inside one constraint must share a shape class: all
+scalar, or all indexed into the same tensor with the same rank.
+Mixing shapes is rejected at init time by
+:meth:`~macrostat.core.parameters.Parameters.verify_constraints`.
 
 
 Adding a constraint to your own model
@@ -123,17 +194,27 @@ parameter lifecycle.
 **Init-time verification.**
 :meth:`~macrostat.core.parameters.Parameters.verify_constraints` is
 called once when a :class:`~macrostat.core.parameters.Parameters`
-instance is constructed. It catches three classes of error:
+instance is constructed. It runs six structural checks and one
+soft check, all of which raise :class:`ConstraintError` (a
+:class:`ValueError` subclass) on failure:
 
 * A constraint references a parameter name that does not exist in
-  ``self.values``. The raised :class:`ValueError` lists the unknown
-  name and the available parameters.
-* The same parameter is declared as the derived (residual)
-  parameter in two or more constraints. The raised
-  :class:`ValueError` lists the duplicate names.
-* A parameter is the derived parameter in one constraint and a
-  free parameter in another. The raised :class:`ValueError`
-  describes the circular dependency.
+  ``self.values``. The error lists the unknown name and the
+  available parameters.
+* The same parameter is declared as the derived parameter in two or
+  more constraints. The error lists the duplicates.
+* A parameter is the derived parameter in one constraint and a free
+  parameter in another; chained constraints are not supported.
+* A constraint references a parameter name that cannot be located
+  by the resolver. This is a defensive check against divergence
+  between :meth:`vectorize_parameters` and
+  :meth:`get_constraint_resolver`.
+* A constraint mixes scalar and indexed parameter locations, spans
+  multiple tensor keys, or mixes index ranks. All parameters in one
+  constraint must share a shape class.
+* The prospective post-enforcement value of the derived parameter
+  lies outside its declared bounds. Catches misdeclared constraints
+  at init time rather than after enforcement.
 
 If the default values stored in ``self.values`` do not satisfy a
 declared constraint, ``verify_constraints`` does not raise. It
@@ -152,11 +233,16 @@ modifies ``self.values`` in place.
 **Step-time enforcement.** During simulation,
 :meth:`~macrostat.core.behavior.Behavior.apply_parameter_shocks`
 applies any scenario shocks to the parameter tensors and then runs
-each constraint's :meth:`LinearConstraint.enforce` again on the
-shocked tensors. This second pass keeps the adding-up identity
-intact even when scenarios shock free parameters in the group, and
-because it operates on tensors with ``requires_grad=True``, autograd
-sees the residual relationship at every timestep.
+each constraint's :meth:`LinearConstraint.apply` on the shocked
+tensors, handing in the resolver obtained from
+:meth:`~macrostat.core.parameters.Parameters.get_constraint_resolver`.
+The resolver and constraint list are fetched fresh on every call,
+so the step-time view of the parameter layout always matches the
+current :class:`~macrostat.core.parameters.Parameters` instance.
+This second pass keeps the adding-up identity intact even when
+scenarios shock free parameters in the group, and because it
+operates on tensors with ``requires_grad=True``, autograd sees the
+residual relationship at every timestep.
 
 **Helpers for callers.**
 :meth:`~macrostat.core.parameters.Parameters.get_free_param_names`

--- a/docs/user_guide/core/constraints.rst
+++ b/docs/user_guide/core/constraints.rst
@@ -1,0 +1,178 @@
+================
+Constraints
+================
+.. currentmodule:: macrostat.core.constraints
+
+Many SFC and behavioral models have *adding-up* relationships between
+parameters. Tobin portfolio shares must sum to one, the corresponding
+rate sensitivities must sum to zero, factor income shares must close
+to total income, and so on. The :class:`LinearConstraint` system lets
+a model declare these relationships once, and MacroStat enforces them
+both at parameter initialization and inside every simulation step,
+without breaking autograd.
+
+Constructor
+~~~~~~~~~~~
+.. autosummary::
+
+   LinearConstraint
+
+Properties and methods
+~~~~~~~~~~~~~~~~~~~~~~
+.. autosummary::
+
+   LinearConstraint.free_params
+   LinearConstraint.derived_param
+   LinearConstraint.enforce
+
+
+Residual parameterization
+=========================
+
+A :class:`LinearConstraint` enforces
+
+.. math::
+
+   \sum_{i \in \text{group}} p_i = T
+
+by treating the **last** parameter in ``param_names`` as the residual
+of the others:
+
+.. math::
+
+   p_{\text{derived}} = T - \sum_{i \in \text{free}} p_i.
+
+The free parameters remain independent. The derived parameter is
+computed from them. Because the derivation is a linear combination
+of tensors, the operation is fully differentiable: autograd records
+the dependency
+
+.. math::
+
+   \frac{\partial p_{\text{derived}}}{\partial p_i} = -1
+   \quad \text{for every free } p_i,
+
+and the gradient of any downstream loss with respect to
+``p_derived`` is zero by construction. This is the correct behavior:
+``p_derived`` is no longer a free parameter, so its sensitivity is
+absorbed into the free parameters of the same group. See
+:doc:`../diff` for an "Expected disagreements" note that revisits
+this from the Jacobian side.
+
+
+Declaring constraints on a model
+================================
+
+Constraints are declared by overriding
+:meth:`~macrostat.core.parameters.Parameters.get_constraints` on the
+model's :class:`~macrostat.core.parameters.Parameters` subclass. The
+method returns an ordered tuple of :class:`LinearConstraint`
+instances. As an example, the GL06INSOUT model declares five
+constraints for its 4-asset Tobin portfolio (M1, M2, Bills, Bonds),
+with M1 cash as the residual asset in every group:
+
+.. literalinclude:: ../../../src/macrostat/models/GL06INSOUT/parameters.py
+   :language: python
+   :pyobject: ParametersGL06INSOUT.get_constraints
+
+Each :class:`LinearConstraint` accepts:
+
+* ``param_names`` (``tuple[str, ...]``): all parameters in the group.
+  The **last** entry is the derived (residual) parameter; everything
+  before it is free.
+* ``target`` (``float``): the value the group must sum to.
+
+The order of constraints in the returned tuple is preserved. If a
+parameter is the derived parameter in one constraint and a free
+parameter in another, MacroStat does not topologically reorder for
+you. The user is responsible for ordering such that each constraint
+is well-defined when it runs.
+
+
+Adding a constraint to your own model
+=====================================
+
+To add a new constraint group to a model:
+
+1. Open the model's ``parameters.py`` and locate the
+   :class:`~macrostat.core.parameters.Parameters` subclass.
+2. Override or extend the ``get_constraints()`` method so that it
+   returns a tuple of :class:`LinearConstraint` instances. If the
+   parent already declares constraints, return ``super().get_constraints() + (...)``.
+3. Choose which parameter in the group is the residual. This is
+   typically the *buffer-stock* asset, the *anchor* category, or
+   any parameter you do not want to estimate independently. List it
+   **last** in ``param_names``.
+4. Pick the ``target`` (1.0 for shares, 0.0 for sensitivities, or
+   any other linear sum).
+5. Re-instantiate the parameters object. ``verify_constraints()`` is
+   called automatically and will raise if the constraint is
+   ill-formed; ``enforce_constraints()`` then adjusts the residual
+   parameter to satisfy the sum.
+
+Existing models that do not declare any constraints need no
+changes. Constraints are opt-in.
+
+
+Verification and enforcement
+============================
+
+Constraints are checked and enforced at several points in the
+parameter lifecycle.
+
+**Init-time verification.**
+:meth:`~macrostat.core.parameters.Parameters.verify_constraints` is
+called once when a :class:`~macrostat.core.parameters.Parameters`
+instance is constructed. It catches three classes of error:
+
+* A constraint references a parameter name that does not exist in
+  ``self.values``. The raised :class:`ValueError` lists the unknown
+  name and the available parameters.
+* The same parameter is declared as the derived (residual)
+  parameter in two or more constraints. The raised
+  :class:`ValueError` lists the duplicate names.
+* A parameter is the derived parameter in one constraint and a
+  free parameter in another. The raised :class:`ValueError`
+  describes the circular dependency.
+
+If the default values stored in ``self.values`` do not satisfy a
+declared constraint, ``verify_constraints`` does not raise. It
+instead emits a warning of the form
+``"Constraint violation in defaults: sum(...) = ..., target = ...."``
+so the user knows that the residual parameter will be adjusted on
+the next call to ``enforce_constraints``.
+
+**Init-time enforcement.**
+:meth:`~macrostat.core.parameters.Parameters.enforce_constraints`
+runs immediately after verification. For each constraint, it
+overwrites the derived parameter's value with
+``target - sum(free)``. This is a float-level operation that
+modifies ``self.values`` in place.
+
+**Step-time enforcement.** During simulation,
+:meth:`~macrostat.core.behavior.Behavior.apply_parameter_shocks`
+applies any scenario shocks to the parameter tensors and then runs
+each constraint's :meth:`LinearConstraint.enforce` again on the
+shocked tensors. This second pass keeps the adding-up identity
+intact even when scenarios shock free parameters in the group, and
+because it operates on tensors with ``requires_grad=True``, autograd
+sees the residual relationship at every timestep.
+
+**Helpers for callers.**
+:meth:`~macrostat.core.parameters.Parameters.get_free_param_names`
+returns the parameter names that are not derived by any
+constraint. Use it whenever you want to iterate over the parameters
+that are actually independent (for calibration, sampling, or
+diagnostics).
+
+
+See also
+========
+
+* :doc:`parameters` for the full Parameters API including the
+  constraint hooks.
+* :doc:`behavior` for the role of ``apply_parameter_shocks`` in
+  step-time enforcement.
+* :doc:`../diff` for how the residual parameterization shows up in
+  numerical and autograd Jacobians.
+* :doc:`../constraints_example` for a runnable notebook walkthrough.

--- a/docs/user_guide/core/index.rst
+++ b/docs/user_guide/core/index.rst
@@ -29,3 +29,4 @@ The following pages contain an overview of the components of the core module and
    Scenarios <scenarios>
    Variables <variables>
    Behavior <behavior>
+   Constraints <constraints>

--- a/docs/user_guide/core/parameters.rst
+++ b/docs/user_guide/core/parameters.rst
@@ -3,6 +3,12 @@ Parameters
 ================
 .. currentmodule:: macrostat.core.parameters
 
+.. seealso::
+
+   :doc:`constraints` documents the :class:`~macrostat.core.constraints.LinearConstraint`
+   system and the :meth:`Parameters.get_constraints` hook used to declare
+   adding-up relationships between parameters.
+
 This class is the base class for all parameter classes. It contains the common methods for all parameter classes.
 
 Constructor
@@ -36,6 +42,15 @@ Parameter Management
    Parameters.set_unit
    Parameters.verify_bounds
    Parameters.verify_parameters
+
+Constraints
+~~~~~~~~~~~
+.. autosummary::
+
+   Parameters.get_constraints
+   Parameters.verify_constraints
+   Parameters.enforce_constraints
+   Parameters.get_free_param_names
 
 Notes
 ~~~~~

--- a/docs/user_guide/diff.rst
+++ b/docs/user_guide/diff.rst
@@ -20,6 +20,7 @@ The core pieces live in :mod:`macrostat.diff`:
 * :class:`macrostat.diff.JacobianAutograd`
 * :class:`macrostat.diff.JacobianNumerical`
 * :func:`macrostat.diff.check_model_differentiability`
+* :func:`macrostat.diff.compare_jacobian_dicts`
 
 
 Quick start
@@ -50,9 +51,68 @@ define a scalar loss and compute gradients as follows:
     jac_auto = JacobianAutograd(model)
     grads_rev = jac_auto.compute(loss_fn=loss_fn, mode="rev")
 
-    # Numerical finite-difference gradients
-    jac_num = JacobianNumerical(model, epsilon=1e-5)
-    grads_num = jac_num.compute(loss_fn=loss_fn, mode="central")
+    # Numerical finite-difference gradients (default: log-space, eps=1e-3)
+    jac_num_log = JacobianNumerical(model)
+    grads_num_log = jac_num_log.compute(loss_fn=loss_fn, mode="central")
+
+    # Or in direct space, useful when any parameter equals zero
+    jac_num_direct = JacobianNumerical(
+        model, epsilon=1e-5, parameter_space="direct"
+    )
+    grads_num_direct = jac_num_direct.compute(loss_fn=loss_fn, mode="central")
+
+
+Direct vs log-space perturbations
+---------------------------------
+
+:class:`~macrostat.diff.JacobianNumerical` supports two perturbation
+schemes, controlled by the ``parameter_space`` argument.
+
+**Direct space** ``parameter_space="direct"`` perturbs each parameter
+additively:
+
+.. math::
+
+    \frac{\partial f}{\partial p}
+    \approx \frac{f(p + \varepsilon) - f(p - \varepsilon)}{2\varepsilon}.
+
+This is the textbook central difference. It works for any parameter
+value, including zero, but the absolute step size has no relation to
+the parameter scale, so the same ``epsilon`` is too small for
+parameters with magnitudes near unity and too large for parameters
+near zero.
+
+**Log space** ``parameter_space="log"`` (the default) perturbs each
+parameter multiplicatively:
+
+.. math::
+
+    \frac{\partial f}{\partial p}
+    \approx \frac{f(p \cdot e^{\varepsilon}) - f(p \cdot e^{-\varepsilon})}
+                {p \cdot (e^{\varepsilon} - e^{-\varepsilon})}.
+
+The perturbation is now a fixed *fraction* of the parameter value,
+so the same ``epsilon`` (default ``1e-3``, roughly a 0.1% relative
+step) is appropriate across parameters of very different magnitudes.
+This is the recommended default for SFC and behavioral models, where
+parameter scales differ by many orders of magnitude.
+
+Choice of ``epsilon`` is a tradeoff: large values amplify
+truncation error from the finite-difference formula, small values
+amplify floating-point roundoff. For float32 in log space, values
+between ``1e-4`` and ``1e-2`` typically work well; ``1e-3`` is the
+package default.
+
+**Zero-parameter caveat.** Log-space perturbation is undefined when a
+parameter equals zero (you cannot take the log of zero, and the
+denominator vanishes). :class:`~macrostat.diff.JacobianNumerical`
+detects this case during ``compute`` and raises
+``ValueError: Cannot use log-space with zero parameters: [...]``.
+For example, the :class:`~macrostat.models.LINEAR2D` test model has
+a parameter ``x0_2`` that defaults to zero, so its tests must
+explicitly pass ``parameter_space="direct"``. Negative parameters
+are handled in log space using a sign-preserving transformation
+``sign(p) * exp(log(abs(p)) +/- eps)``.
 
 
 High-level differentiability check
@@ -74,22 +134,101 @@ For a more complete diagnostic, use
         compare_forward_reverse=True,
         compare_numerical=True,
         numerical_mode="central",
-        epsilon=1e-5,
+        epsilon=1e-3,
+        parameter_space="log",
     )
 
     print(report.summary())
 
 The resulting :class:`macrostat.diff.DifferentiabilityReport` contains:
 
-* ``nan_or_inf`` – whether any gradient contains NaNs or Infs.
-* ``rel_err_fwd_rev`` – relative discrepancy between forward- and reverse-mode
+* ``nan_or_inf`` -- whether any gradient contains NaNs or Infs.
+* ``rel_err_fwd_rev`` -- relative discrepancy between forward- and reverse-mode
   autograd gradients.
-* ``rel_err_autodiff_num`` – relative discrepancy between autograd and
+* ``rel_err_autodiff_num`` -- relative discrepancy between autograd and
   numerical finite-difference gradients.
 
 Rather than only returning a pass/fail flag, the report is intended to help
 you interpret *how accurate* the gradients are (e.g. "accurate to about
 ``1e-3`` relative error" on a given model and loss).
+
+Set ``parameter_space="direct"`` if your model has any parameter
+equal to zero. The default is ``"log"``.
+
+
+Per-parameter Jacobian comparison
+---------------------------------
+
+When the high-level check reports a disagreement, the next question
+is *which parameter* is responsible.
+:func:`~macrostat.diff.compare_jacobian_dicts` performs an
+element-wise, per-parameter comparison of two Jacobian dictionaries
+and returns a :class:`~macrostat.diff.JacobianComparisonReport` with
+the following fields per parameter:
+
+* ``max_abs_diff``, ``mean_abs_diff`` -- absolute differences across
+  all elements of the parameter's Jacobian slice.
+* ``max_rel_diff``, ``mean_rel_diff`` -- the same, normalised by
+  ``max(|a|, |b|)`` clipped to one.
+* ``num_close`` / ``num_elements`` -- how many entries are within
+  the ``atol``/``rtol`` tolerance.
+* ``has_nan_inf`` -- whether either Jacobian contains NaNs or Infs.
+
+A typical workflow:
+
+.. code-block:: python
+
+    from macrostat.diff import (
+        JacobianAutograd, JacobianNumerical, compare_jacobian_dicts,
+    )
+
+    jac_auto = JacobianAutograd(model).compute(loss_fn=loss_fn, mode="rev")
+    jac_num = JacobianNumerical(model).compute(loss_fn=loss_fn, mode="central")
+
+    report = compare_jacobian_dicts(
+        jac_auto, jac_num, method_a="autograd", method_b="numerical"
+    )
+    print(report.summary())
+
+The summary prints one row per parameter, sorted by descending
+relative disagreement, so the offending parameters are at the top.
+See :doc:`jacobian_diagnostics` for a runnable walkthrough that
+applies this workflow to LINEAR2D and several GL06 variants.
+
+
+Expected disagreements
+----------------------
+
+Two classes of "disagreement" between autograd and numerical
+Jacobians are expected and not bugs.
+
+**Constraint-derived parameters.** When a model declares a
+:class:`~macrostat.core.constraints.LinearConstraint`, the derived
+(residual) parameter is no longer free: its value is fixed by the
+adding-up identity. Autograd correctly reports a zero gradient for
+the derived parameter and absorbs the sensitivity into the free
+parameters of the same group. Numerical Jacobians computed by
+perturbing the *free* parameters agree with autograd; numerical
+Jacobians computed by perturbing the *derived* parameter directly
+will disagree, because such a perturbation would violate the
+constraint. See :doc:`core/constraints` for the residual
+parameterization and :doc:`constraints_example` for a worked
+example.
+
+**Step-function operations.** Operations like
+``torch.where(x > 0, a, b)``, ``torch.clamp``, and any other
+discontinuous switch are non-differentiable through the condition
+argument. Autograd reports zero gradient at the discontinuity, while
+finite differences see a finite jump whenever the perturbation
+straddles it. The disagreement is real but local, and it disappears
+when the step function is replaced by a smooth approximation. The
+:class:`~macrostat.core.behavior.Behavior` base class provides
+:meth:`~macrostat.core.behavior.Behavior.diffwhere`,
+:meth:`~macrostat.core.behavior.Behavior.tanhmask`,
+:meth:`~macrostat.core.behavior.Behavior.diffmin`, and
+:meth:`~macrostat.core.behavior.Behavior.diffmax` for this purpose.
+:doc:`jacobian_diagnostics` shows how to localize this kind of
+disagreement to a specific parameter, timestep, and output.
 
 
 Test model: LINEAR2D
@@ -109,3 +248,7 @@ in the test suite to confirm that:
 * Forward and reverse autograd agree to high precision, and
 * Autograd gradients match finite-difference gradients up to a small relative
   error.
+
+Because LINEAR2D has a parameter (``x0_2``) that defaults to zero,
+log-space perturbation is undefined for it, and its differentiability
+tests set ``parameter_space="direct"`` explicitly.

--- a/docs/user_guide/index.rst
+++ b/docs/user_guide/index.rst
@@ -13,6 +13,7 @@ see :ref:`api`.
    Core Model Structure <core/index>
    Differentiability and Jacobians <diff>
    Parameter constraints example <constraints_example>
+   Jacobian diagnostics <jacobian_diagnostics>
    Parameter Estimation and Calibration <estimation>
    Causality Analysis <causality>
    Parameter Space Sampling <sample>

--- a/docs/user_guide/index.rst
+++ b/docs/user_guide/index.rst
@@ -12,6 +12,7 @@ see :ref:`api`.
    Getting Started <getting_started>
    Core Model Structure <core/index>
    Differentiability and Jacobians <diff>
+   Parameter constraints example <constraints_example>
    Parameter Estimation and Calibration <estimation>
    Causality Analysis <causality>
    Parameter Space Sampling <sample>

--- a/docs/user_guide/jacobian_diagnostics.ipynb
+++ b/docs/user_guide/jacobian_diagnostics.ipynb
@@ -1,0 +1,339 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "intro",
+   "metadata": {},
+   "source": "# Jacobian diagnostics\n\nWhen `JacobianAutograd` and `JacobianNumerical` disagree on a model, the next question is *why*. This notebook is a runnable companion to [Differentiability and Jacobian Tools](diff.rst). It walks through three progressively trickier models, shows how `compare_jacobian_dicts` localises the disagreement to specific parameters, and closes with a decision tree for reading a report.\n\n* **LINEAR2D**: the test model with an analytical Jacobian and a zero parameter. Demonstrates `parameter_space=\"direct\"`.\n* **GL06SIMEX**: a small SFC model whose autograd and numerical Jacobians agree cleanly under the default log-space setting.\n* **GL06INSOUT**: the production Tobin portfolio model, which uses a step-function `torch.where` inside `portfolio_switches`. The diagnostic shows up as a subset of parameters with visibly worse agreement than the others, and testing different values of `epsilon` in the numerical differentiation confirms that the disagreement is caused by the step function."
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "version",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-10T08:12:13.163602Z",
+     "iopub.status.busy": "2026-04-10T08:12:13.163472Z",
+     "iopub.status.idle": "2026-04-10T08:12:14.034842Z",
+     "shell.execute_reply": "2026-04-10T08:12:14.034428Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "macrostat version: 0.5.7.post1.dev7+g35c4d7655.d20260409\n",
+      "torch version:     2.11.0+cu130\n"
+     ]
+    }
+   ],
+   "source": [
+    "import sys, os\n",
+    "sys.path.insert(0, os.path.abspath('.'))\n",
+    "\n",
+    "import macrostat\n",
+    "import torch\n",
+    "\n",
+    "from macrostat.models import get_model\n",
+    "from macrostat.diff import (\n",
+    "    JacobianAutograd,\n",
+    "    JacobianNumerical,\n",
+    "    compare_jacobian_dicts,\n",
+    ")\n",
+    "from _doc_helpers import (\n",
+    "    mean_nominal_output,\n",
+    "    mean_national_income,\n",
+    "    final_state_norm,\n",
+    ")\n",
+    "\n",
+    "print('macrostat version:', macrostat.__version__)\n",
+    "print('torch version:    ', torch.__version__)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "linear2d-section",
+   "metadata": {},
+   "source": "## LINEAR2D: direct-space differences\n\nLINEAR2D is a 2x2 linear map $x_{t+1} = A x_t$ with six parameters: four matrix entries and two initial conditions. The initial condition `x0_2` defaults to zero, so log-space perturbation is undefined for it. We therefore set `parameter_space=\"direct\"` with a small `epsilon=1e-5`, which is the standard central-difference setup. With an analytical Jacobian available on this model, we expect low but non-zero relative error dominated by truncation of the finite-difference formula."
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "linear2d-code",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-10T08:12:14.035986Z",
+     "iopub.status.busy": "2026-04-10T08:12:14.035812Z",
+     "iopub.status.idle": "2026-04-10T08:12:15.600294Z",
+     "shell.execute_reply": "2026-04-10T08:12:15.599747Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Jacobian comparison: autograd vs numerical (direct, eps=1e-5)\n",
+      "Parameters compared: 6\n",
+      "Overall max abs diff: 5.045e-03  max rel diff: 5.045e-03\n",
+      "\n",
+      "Parameter                                   max_abs   mean_abs    max_rel   mean_rel        close nan/inf\n",
+      "---------------------------------------------------------------------------------------------------------\n",
+      "x0_2                                      5.045e-03  5.045e-03  5.045e-03  5.045e-03          0/1      no\n",
+      "x0_1                                      4.689e-03  4.689e-03  4.689e-03  4.689e-03          0/1      no\n",
+      "a12                                       3.227e-04  3.227e-04  2.999e-04  2.999e-04          1/1      no\n",
+      "a22                                       1.304e-04  1.304e-04  1.304e-04  1.304e-04          1/1      no\n",
+      "a11                                       2.871e-04  2.871e-04  9.710e-05  9.710e-05          1/1      no\n",
+      "a21                                       1.221e-04  1.221e-04  9.525e-05  9.525e-05          1/1      no\n"
+     ]
+    }
+   ],
+   "source": [
+    "model = get_model('LINEAR2D')()\n",
+    "\n",
+    "jac_auto = JacobianAutograd(model).compute(\n",
+    "    loss_fn=final_state_norm, mode='rev',\n",
+    ")\n",
+    "jac_num = JacobianNumerical(\n",
+    "    model, parameter_space='direct', epsilon=1e-5,\n",
+    ").compute(loss_fn=final_state_norm, mode='central', num_workers=1)\n",
+    "\n",
+    "report = compare_jacobian_dicts(\n",
+    "    jac_auto, jac_num,\n",
+    "    method_a='autograd', method_b='numerical (direct, eps=1e-5)',\n",
+    "    rtol=1e-3, atol=1e-6,\n",
+    ")\n",
+    "print(report.summary())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "linear2d-interp",
+   "metadata": {},
+   "source": [
+    "All six parameters land in the ballpark of `1e-4` to `1e-3` relative error. The two initial conditions `x0_1` and `x0_2` sit at the top of the list because they enter linearly and so pick up the full truncation error of the central-difference formula; the matrix entries roll into the propagation and average down. There is no outlier. This is the reference shape of a clean report."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "simex-section",
+   "metadata": {},
+   "source": [
+    "## GL06SIMEX: log-space on a smooth SFC model\n",
+    "\n",
+    "GL06SIMEX is the smallest SFC model in the suite: three free parameters (`TaxRate`, `PropensityToConsumeIncome`, `PropensityToConsumeSavings`) and no portfolio switch. All behaviour is smooth, so log-space perturbation with the default `epsilon=1e-3` should agree with autograd to roughly `1e-4` relative error."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "simex-code",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-10T08:12:15.601417Z",
+     "iopub.status.busy": "2026-04-10T08:12:15.601262Z",
+     "iopub.status.idle": "2026-04-10T08:12:16.935164Z",
+     "shell.execute_reply": "2026-04-10T08:12:16.934785Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Jacobian comparison: autograd vs numerical (log, eps=1e-3)\n",
+      "Parameters compared: 3\n",
+      "Overall max abs diff: 2.362e-02  max rel diff: 4.386e-04\n",
+      "\n",
+      "Parameter                                   max_abs   mean_abs    max_rel   mean_rel        close nan/inf\n",
+      "---------------------------------------------------------------------------------------------------------\n",
+      "PropensityToConsumeIncome                 4.344e-03  4.344e-03  4.386e-04  4.386e-04          1/1      no\n",
+      "PropensityToConsumeSavings                2.014e-03  2.014e-03  2.034e-04  2.034e-04          1/1      no\n",
+      "TaxRate                                   2.362e-02  2.362e-02  5.301e-05  5.301e-05          1/1      no\n"
+     ]
+    }
+   ],
+   "source": [
+    "model = get_model('GL06SIMEX')()\n",
+    "\n",
+    "jac_auto = JacobianAutograd(model).compute(\n",
+    "    loss_fn=mean_national_income, mode='rev',\n",
+    ")\n",
+    "jac_num = JacobianNumerical(model).compute(\n",
+    "    loss_fn=mean_national_income, mode='central', num_workers=1,\n",
+    ")\n",
+    "\n",
+    "report = compare_jacobian_dicts(\n",
+    "    jac_auto, jac_num,\n",
+    "    method_a='autograd', method_b='numerical (log, eps=1e-3)',\n",
+    "    rtol=1e-3, atol=1e-6,\n",
+    ")\n",
+    "print(report.summary())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "simex-interp",
+   "metadata": {},
+   "source": [
+    "All three parameters agree to better than `5e-4` relative error. The max absolute differences look larger (`2e-2` on `TaxRate`) but that reflects the scale of the Jacobian entry, not a disagreement: once normalised by the magnitude, the report is clean. This is the pattern to expect on a smooth model: relative error sits near the log-space truncation floor."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "insout-section",
+   "metadata": {},
+   "source": "## GL06INSOUT: localising a step-function disagreement\n\nThe Tobin portfolio model behaves differently. Some parameters agree well and others show visibly worse agreement. The goal here is not to fix the disagreement but to use `compare_jacobian_dicts` to identify which parameters are affected, and then to confirm, by testing different values of `epsilon` in the numerical differentiation, that the cause is a step-function operation in the model code rather than a smooth numerical artefact."
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "insout-code",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-10T08:12:16.936106Z",
+     "iopub.status.busy": "2026-04-10T08:12:16.936010Z",
+     "iopub.status.idle": "2026-04-10T08:12:22.848639Z",
+     "shell.execute_reply": "2026-04-10T08:12:22.848306Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Jacobian comparison: autograd vs numerical (log, eps=1e-3)\n",
+      "Parameters compared: 5\n",
+      "Overall max abs diff: 1.899e+00  max rel diff: 2.077e-01\n",
+      "\n",
+      "Parameter                                   max_abs   mean_abs    max_rel   mean_rel        close nan/inf\n",
+      "---------------------------------------------------------------------------------------------------------\n",
+      "WealthShareBills_Constant                 1.899e+00  1.899e+00  2.077e-01  2.077e-01          0/1      no\n",
+      "WealthShareM2_Constant                    5.841e-02  5.841e-02  5.841e-02  5.841e-02          0/1      no\n",
+      "WealthShareBonds_Constant                 1.534e-01  1.534e-01  7.729e-03  7.729e-03          0/1      no\n",
+      "InventorySalesRatioBaseline               9.693e-02  9.693e-02  3.941e-03  3.941e-03          0/1      no\n",
+      "TaxRate                                   3.356e-01  3.356e-01  1.868e-04  1.868e-04          1/1      no\n"
+     ]
+    }
+   ],
+   "source": [
+    "model = get_model('GL06INSOUT')()\n",
+    "\n",
+    "sample_params = [\n",
+    "    'WealthShareM2_Constant',\n",
+    "    'WealthShareBills_Constant',\n",
+    "    'WealthShareBonds_Constant',\n",
+    "    'TaxRate',\n",
+    "    'InventorySalesRatioBaseline',\n",
+    "]\n",
+    "\n",
+    "jac_auto = JacobianAutograd(model).compute(\n",
+    "    loss_fn=mean_nominal_output, mode='rev',\n",
+    ")\n",
+    "jac_num = JacobianNumerical(model).compute(\n",
+    "    loss_fn=mean_nominal_output, mode='central', num_workers=1,\n",
+    "    param_names=sample_params,\n",
+    ")\n",
+    "\n",
+    "jac_auto_subset = {k: jac_auto[k] for k in sample_params}\n",
+    "\n",
+    "report = compare_jacobian_dicts(\n",
+    "    jac_auto_subset, jac_num,\n",
+    "    method_a='autograd', method_b='numerical (log, eps=1e-3)',\n",
+    "    rtol=1e-3, atol=1e-6,\n",
+    ")\n",
+    "print(report.summary())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "insout-interp",
+   "metadata": {},
+   "source": "The report is sorted by descending relative disagreement. `TaxRate` and `InventorySalesRatioBaseline` sit at the bottom with relative errors in the `1e-4` to `1e-3` range, consistent with the clean-model baseline from GL06SIMEX. The three Tobin constants are two to three orders of magnitude worse: `WealthShareBonds_Constant` at `8e-3`, `WealthShareM2_Constant` at `6e-2`, and `WealthShareBills_Constant` at `2e-1`.\n\nThe disagreement is concentrated on the three Tobin portfolio constants and not on the unrelated parameters. This tells us the affected parameters share a structural role in the model, and that role must involve a non-smooth operation. In GL06INSOUT, the `portfolio_switches` method uses a step-function `torch.where` to select between the M1- and M2-dominated regimes of the Tobin allocation. Parameters that shift the baseline portfolio composition can push the economy across that switch for some timesteps. When a central-difference perturbation of size `epsilon` straddles the discontinuity, the numerical Jacobian sees a finite jump while autograd reports zero gradient at the switch."
+  },
+  {
+   "cell_type": "markdown",
+   "id": "eps-sweep-section",
+   "metadata": {},
+   "source": "## Testing different values of epsilon in the numerical differentiation\n\nTesting different values of `epsilon` in the numerical differentiation will reveal whether the disagreement comes from a step-function operation or from a smooth numerical artefact. A step-function operation produces a non-monotone relationship between `epsilon` and the relative disagreement: at large `epsilon` the perturbation spans a region much wider than the discontinuity and the numerical derivative is dominated by whichever side of the switch each perturbed trajectory lands on, producing a large disagreement with autograd; at very small `epsilon` roundoff and cancellation in the central-difference formula erode the agreement from the other direction; and between these two regimes sits a value where the disagreement is smallest. A smooth numerical artefact, by contrast, produces a monotone curve.\n\nThe following cell computes the numerical Jacobian at three values of `epsilon` on the parameter with the largest disagreement in the previous report, `WealthShareBills_Constant`."
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "eps-sweep-code",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-10T08:12:22.849726Z",
+     "iopub.status.busy": "2026-04-10T08:12:22.849630Z",
+     "iopub.status.idle": "2026-04-10T08:12:28.684101Z",
+     "shell.execute_reply": "2026-04-10T08:12:28.683570Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Relative disagreement on WealthShareBills_Constant vs epsilon:\n",
+      "  eps=1e-02  max_rel_diff=1.186e+00\n",
+      "  eps=1e-03  max_rel_diff=2.077e-01\n",
+      "  eps=1e-05  max_rel_diff=2.503e-01\n"
+     ]
+    }
+   ],
+   "source": [
+    "worst = 'WealthShareBills_Constant'\n",
+    "eps_values = [1e-2, 1e-3, 1e-5]\n",
+    "rel_diffs = {}\n",
+    "\n",
+    "for eps in eps_values:\n",
+    "    jn = JacobianNumerical(model, epsilon=eps).compute(\n",
+    "        loss_fn=mean_nominal_output, mode='central', num_workers=1,\n",
+    "        param_names=[worst],\n",
+    "    )\n",
+    "    a = jac_auto[worst]\n",
+    "    n = jn[worst]\n",
+    "    denom = torch.maximum(a.abs(), n.abs()).clamp(min=1e-12)\n",
+    "    rel_diffs[eps] = ((a - n).abs() / denom).max().item()\n",
+    "\n",
+    "print(f'Relative disagreement on {worst} vs epsilon:')\n",
+    "for eps, r in rel_diffs.items():\n",
+    "    print(f'  eps={eps:>.0e}  max_rel_diff={r:.3e}')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "eps-sweep-interp",
+   "metadata": {},
+   "source": "The three values show the expected non-monotone pattern. At `eps=1e-2` the perturbation is large enough that the relative disagreement exceeds 100%, well above the other two values. At `eps=1e-3` the disagreement is smallest, around 20%. At `eps=1e-5` it increases again as floating-point cancellation erodes the finite-difference signal. A smooth numerical source of error would produce a monotone curve in `epsilon`; the non-monotone pattern observed here is consistent with a step-function operation, and matches the `portfolio_switches` diagnosis."
+  },
+  {
+   "cell_type": "markdown",
+   "id": "decision-tree",
+   "metadata": {},
+   "source": "## Decision tree: reading a `compare_jacobian_dicts` report\n\nWhen an autograd vs numerical comparison fails on a MacroStat model, use the following checklist before reaching for deeper debugging.\n\n1. **Every parameter at `max_rel_diff` below roughly `1e-3`.** Nothing is wrong. The report is clean.\n2. **One or more parameters with `nan/inf`.** Autograd found a `NaN` or `Inf` in the gradient. Typical causes are divide-by-zero or `log(0)` inside the model behaviour; instrument with `torch.autograd.set_detect_anomaly(True)` and rerun.\n3. **A derived parameter (residual of a `LinearConstraint`) reports `max_rel_diff` of order unity, but autograd gives exactly zero.** Expected. The constraint system absorbs all sensitivity into the free parameters of that group. See the constraint-system notes in [Differentiability and Jacobian Tools](diff.rst) and the worked example in [Parameter constraints](constraints_example.ipynb). If you are numerically perturbing the *derived* parameter directly, stop: that perturbation violates the constraint. Perturb the free parameters instead.\n4. **A small subset of parameters shows disagreement two or more orders of magnitude worse than the rest, and the worst offenders share a structural role in the model.** Suspect a step-function operation. Recompute the numerical Jacobian at several values of `epsilon` on the worst offender as shown in the previous section; a non-monotone relationship between `epsilon` and the relative disagreement confirms the diagnosis. Locate the switch with a `grep` for `torch.where`, `torch.clamp`, or explicit `if` branches in the behaviour code, and replace it with one of the smooth alternatives provided by `Behavior.diffwhere`, `Behavior.tanhmask`, `Behavior.diffmin`, or `Behavior.diffmax`.\n5. **All parameters disagree uniformly, around `1e-2` or worse.** Likely a bug in the numerical configuration rather than the model. Check whether `parameter_space=\"log\"` is being used with zero parameters (should raise, but verify), whether `epsilon` is appropriate for the parameter scale, and whether the loss function itself is well-conditioned.\n\nFor the constraint system specifically, see [Constraints](core/constraints.rst) and the [constraints example notebook](constraints_example.ipynb)."
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.13.5"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/src/macrostat/core/__init__.py
+++ b/src/macrostat/core/__init__.py
@@ -15,9 +15,18 @@ The macrostat.core module consists of the following classes
 """
 
 from .behavior import Behavior
+from .constraints import LinearConstraint
 from .model import Model
 from .parameters import BoundaryError, Parameters
 from .scenarios import Scenarios
 from .variables import Variables
 
-__all__ = ["Behavior", "Parameters", "Model", "Scenarios", "Variables", "BoundaryError"]
+__all__ = [
+    "Behavior",
+    "BoundaryError",
+    "LinearConstraint",
+    "Model",
+    "Parameters",
+    "Scenarios",
+    "Variables",
+]

--- a/src/macrostat/core/__init__.py
+++ b/src/macrostat/core/__init__.py
@@ -6,16 +6,25 @@ The macrostat.core module consists of the following classes
 .. autosummary::
     :toctree: core
 
-    BoundaryError
     Behavior
+    BoundaryError
+    ConstraintError
+    ConstraintResolver
+    LinearConstraint
     Model
+    ParameterLocation
     Parameters
     Scenarios
     Variables
 """
 
 from .behavior import Behavior
-from .constraints import LinearConstraint
+from .constraints import (
+    ConstraintError,
+    ConstraintResolver,
+    LinearConstraint,
+    ParameterLocation,
+)
 from .model import Model
 from .parameters import BoundaryError, Parameters
 from .scenarios import Scenarios
@@ -24,8 +33,11 @@ from .variables import Variables
 __all__ = [
     "Behavior",
     "BoundaryError",
+    "ConstraintError",
+    "ConstraintResolver",
     "LinearConstraint",
     "Model",
+    "ParameterLocation",
     "Parameters",
     "Scenarios",
     "Variables",

--- a/src/macrostat/core/behavior.py
+++ b/src/macrostat/core/behavior.py
@@ -48,10 +48,14 @@ class Behavior(torch.nn.Module):
         # Initialize the parent class
         super().__init__()
 
-        # Initialize the parameters
+        # Initialize the parameters. Keep the Parameters instance itself
+        # so step-time calls can always ask for a fresh resolver and
+        # constraint list. Snapshotting them at init time would freeze
+        # the view of the parameter layout at construction and make any
+        # future mutation API silently desynchronise.
+        self.parameters = parameters
         self.params = parameters.to_nn_parameters()
         self.hyper = parameters.hyper
-        self.constraints = parameters.get_constraints()
 
         # Initialize the scenarios
         self.scenarios = scenarios.to_nn_parameters(scenario=scenario)
@@ -228,9 +232,15 @@ class Behavior(torch.nn.Module):
 
             params[key] = value * mul + add
 
-        # Enforce adding-up constraints (differentiable)
-        for c in self.constraints:
-            c.enforce(params)
+        # Enforce adding-up constraints (differentiable). The resolver
+        # and constraint list are fetched fresh on every call so the
+        # step-time view of the parameter layout always matches the
+        # current Parameters instance.
+        constraints = self.parameters.get_constraints()
+        if constraints:
+            resolver = self.parameters.get_constraint_resolver()
+            for c in constraints:
+                c.apply(params, resolver)
 
         return params
 

--- a/src/macrostat/core/behavior.py
+++ b/src/macrostat/core/behavior.py
@@ -51,6 +51,7 @@ class Behavior(torch.nn.Module):
         # Initialize the parameters
         self.params = parameters.to_nn_parameters()
         self.hyper = parameters.hyper
+        self.constraints = parameters.get_constraints()
 
         # Initialize the scenarios
         self.scenarios = scenarios.to_nn_parameters(scenario=scenario)
@@ -226,6 +227,11 @@ class Behavior(torch.nn.Module):
                             add = add + (ix * scenario[f"{s}_{key}_add"])
 
             params[key] = value * mul + add
+
+        # Enforce adding-up constraints (differentiable)
+        for c in self.constraints:
+            c.enforce(params)
+
         return params
 
     ############################################################################

--- a/src/macrostat/core/constraints.py
+++ b/src/macrostat/core/constraints.py
@@ -1,0 +1,77 @@
+# Copyright (c) 2025 Karl Naumann-Woleske
+# Author: Karl Naumann-Woleske <karl@naumannwoleske.com>
+# SPDX-License-Identifier: MIT
+
+"""Linear adding-up constraints for parameter groups."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import torch
+
+
+@dataclass(frozen=True)
+class LinearConstraint:
+    """A linear adding-up constraint on a group of parameters.
+
+    Enforces that a group of parameters sums to a target value via
+    residual parameterization: the last parameter in ``param_names``
+    is derived (computed as ``target - sum(free_params)``), while
+    all others remain free.
+
+    Parameters
+    ----------
+    param_names : tuple[str, ...]
+        Names of all parameters in this constraint group.
+        The **last** element is the derived (residual) parameter.
+    target : float
+        The value that all parameters in the group must sum to.
+
+    Examples
+    --------
+    Portfolio constants must sum to 1:
+
+    >>> c = LinearConstraint(
+    ...     param_names=("Bills_Const", "Bonds_Const", "M1_Const"),
+    ...     target=1.0,
+    ... )
+    >>> c.free_params
+    ('Bills_Const', 'Bonds_Const')
+    >>> c.derived_param
+    'M1_Const'
+    """
+
+    param_names: tuple[str, ...]
+    target: float
+
+    @property
+    def free_params(self) -> tuple[str, ...]:
+        """Parameter names that are free (all except the last)."""
+        return self.param_names[:-1]
+
+    @property
+    def derived_param(self) -> str:
+        """The parameter name that is derived from the others."""
+        return self.param_names[-1]
+
+    def enforce(self, params: dict[str, torch.Tensor]) -> dict[str, torch.Tensor]:
+        """Enforce the constraint by recomputing the derived parameter.
+
+        This operation is differentiable: the derived parameter's value
+        is a function of the free parameters, so autograd tracks the
+        dependency (``d(derived)/d(free_i) = -1``).
+
+        Parameters
+        ----------
+        params : dict[str, torch.Tensor]
+            Mutable parameter dictionary. Modified in-place and returned.
+
+        Returns
+        -------
+        dict[str, torch.Tensor]
+            The same dictionary with the derived parameter updated.
+        """
+        free_sum = sum(params[name] for name in self.free_params)
+        params[self.derived_param] = free_sum.new_tensor(self.target) - free_sum
+        return params

--- a/src/macrostat/core/constraints.py
+++ b/src/macrostat/core/constraints.py
@@ -2,13 +2,173 @@
 # Author: Karl Naumann-Woleske <karl@naumannwoleske.com>
 # SPDX-License-Identifier: MIT
 
-"""Linear adding-up constraints for parameter groups."""
+"""Linear adding-up constraints for parameter groups.
+
+This module implements residual parameterization for linear adding-up
+constraints of the form ``sum(params) == target``. One parameter in
+each group is designated as the *derived* (residual) parameter and is
+recomputed as ``target - sum(free_params)``. This makes the derived
+parameter a non-leaf tensor with zero autograd gradient; sensitivity
+flows into the free parameters only.
+
+Two abstraction layers are provided:
+
+* :class:`LinearConstraint` declares the constraint in terms of
+  canonical (dotted) parameter names.
+* :class:`ParameterLocation` and :class:`ConstraintResolver` map those
+  names to positions inside the vectorized tensor dictionary that
+  :meth:`macrostat.core.parameters.Parameters.vectorize_parameters`
+  produces. This is what lets the same constraint apply to scalar,
+  sector-indexed vector, and sector-indexed matrix parameters
+  uniformly at step time.
+"""
 
 from __future__ import annotations
 
+import math
 from dataclasses import dataclass
 
 import torch
+
+
+class ConstraintError(ValueError):
+    """Raised for malformed or unresolvable parameter constraints.
+
+    Subclasses :class:`ValueError` so existing code that catches
+    ``ValueError`` continues to work.
+    """
+
+
+@dataclass(frozen=True)
+class ParameterLocation:
+    """Where a named parameter lives in a vectorized tensor dict.
+
+    A :class:`ParameterLocation` is a small value object produced by
+    :class:`ConstraintResolver`. It records the key under which a
+    parameter's tensor appears in the step-time parameter dictionary,
+    together with an index if the parameter is one element of a larger
+    tensor (for example one sector of a 1-D sector-indexed tensor, or
+    one cell of a 2-D sector-by-sector matrix).
+
+    Parameters
+    ----------
+    tensor_key : str
+        Key into the step-time tensor dict (the dict produced by
+        :meth:`macrostat.core.parameters.Parameters.vectorize_parameters`).
+    index : tuple[int, ...] | None
+        ``None`` for scalar slots (the whole dict entry *is* the
+        parameter). ``(i,)`` for 1-D sector-indexed parameters.
+        ``(i, j)`` for 2-D sector-by-sector parameters.
+    """
+
+    tensor_key: str
+    index: tuple[int, ...] | None
+
+    def read(self, params: dict[str, torch.Tensor]) -> torch.Tensor:
+        """Return the tensor slice corresponding to this location.
+
+        Parameters
+        ----------
+        params : dict[str, torch.Tensor]
+            Step-time parameter dictionary.
+
+        Returns
+        -------
+        torch.Tensor
+            The 0-D tensor at this location. For a scalar slot this is
+            the whole dict entry; for indexed slots it is the result of
+            indexing the full tensor, which autograd tracks.
+        """
+        t = params[self.tensor_key]
+        return t if self.index is None else t[self.index]
+
+    def write(self, params: dict[str, torch.Tensor], value: torch.Tensor) -> None:
+        """Write ``value`` into this location, preserving differentiability.
+
+        For scalar slots this is a plain dict rebinding. For indexed
+        slots it uses :func:`torch.Tensor.index_put` with
+        ``accumulate=False``, which is out-of-place and differentiable:
+        gradients flow into ``value`` and into the untouched entries of
+        the base tensor.
+
+        The caller must use the dict after this call and not retain
+        references to the old tensor stored under ``tensor_key``,
+        because indexed writes rebind the dict entry to a new tensor.
+
+        Parameters
+        ----------
+        params : dict[str, torch.Tensor]
+            Step-time parameter dictionary. Modified in place.
+        value : torch.Tensor
+            Scalar tensor to store at this location. For indexed
+            writes the value is reshaped to match the single-element
+            slice expected by :func:`torch.Tensor.index_put`.
+        """
+        if self.index is None:
+            params[self.tensor_key] = value
+            return
+
+        base = params[self.tensor_key]
+        idx_tuple = tuple(
+            torch.tensor([k], dtype=torch.long, device=base.device) for k in self.index
+        )
+        params[self.tensor_key] = base.index_put(
+            idx_tuple, value.reshape(1), accumulate=False
+        )
+
+
+class ConstraintResolver:
+    """Map canonical parameter names to :class:`ParameterLocation` objects.
+
+    A resolver is built once by
+    :meth:`macrostat.core.parameters.Parameters.get_constraint_resolver`
+    and reused across step-time constraint applications. It is the
+    seam that isolates :class:`LinearConstraint` from the details of
+    how ``Parameters.vectorize_parameters`` lays parameters out in the
+    step-time tensor dict.
+
+    Parameters
+    ----------
+    mapping : dict[str, ParameterLocation]
+        Canonical (dotted) parameter name → location in the vectorized
+        tensor dict. Ownership of the mapping passes to the resolver;
+        do not mutate it after construction.
+    """
+
+    def __init__(self, mapping: dict[str, ParameterLocation]):
+        self._map = dict(mapping)
+
+    def locate(self, name: str) -> ParameterLocation:
+        """Return the :class:`ParameterLocation` for ``name``.
+
+        Parameters
+        ----------
+        name : str
+            Canonical (dotted) parameter name as it appears in the
+            constraint declaration.
+
+        Returns
+        -------
+        ParameterLocation
+            The recorded location for this name.
+
+        Raises
+        ------
+        ConstraintError
+            If ``name`` is not known to this resolver.
+        """
+        if name not in self._map:
+            raise ConstraintError(
+                f"Unknown constraint parameter: {name!r}. "
+                f"Known names: {sorted(self._map)}"
+            )
+        return self._map[name]
+
+    def __contains__(self, name: str) -> bool:
+        return name in self._map
+
+    def __len__(self) -> int:
+        return len(self._map)
 
 
 @dataclass(frozen=True)
@@ -20,13 +180,28 @@ class LinearConstraint:
     is derived (computed as ``target - sum(free_params)``), while
     all others remain free.
 
+    The constraint is declared in terms of canonical (dotted)
+    parameter names and is evaluated against a
+    :class:`ConstraintResolver` at step time, which lets the same
+    constraint apply to scalar, vector, or matrix parameter layouts
+    uniformly.
+
     Parameters
     ----------
     param_names : tuple[str, ...]
         Names of all parameters in this constraint group.
         The **last** element is the derived (residual) parameter.
+        Lists are coerced to tuples.
     target : float
         The value that all parameters in the group must sum to.
+        Must be finite and not a bool.
+
+    Raises
+    ------
+    ConstraintError
+        If ``param_names`` has fewer than two entries, contains
+        duplicates, contains non-string names, or if ``target`` is
+        non-finite or a bool.
 
     Examples
     --------
@@ -45,6 +220,54 @@ class LinearConstraint:
     param_names: tuple[str, ...]
     target: float
 
+    def __post_init__(self):
+        # Coerce lists (and other sequences) to tuples. Frozen
+        # dataclass requires object.__setattr__ for mutation.
+        if not isinstance(self.param_names, tuple):
+            try:
+                coerced = tuple(self.param_names)
+            except TypeError as exc:
+                raise ConstraintError(
+                    f"param_names must be a sequence of strings, "
+                    f"got {type(self.param_names).__name__}"
+                ) from exc
+            object.__setattr__(self, "param_names", coerced)
+
+        if len(self.param_names) < 2:
+            raise ConstraintError(
+                f"LinearConstraint needs at least two parameter names "
+                f"(one free and one derived); got {self.param_names!r}"
+            )
+
+        for name in self.param_names:
+            if not isinstance(name, str):
+                raise ConstraintError(
+                    f"LinearConstraint param_names must all be strings; "
+                    f"got {name!r} of type {type(name).__name__}"
+                )
+
+        if len(set(self.param_names)) != len(self.param_names):
+            raise ConstraintError(
+                f"LinearConstraint param_names must be unique; "
+                f"got {self.param_names!r}"
+            )
+
+        # Reject bool explicitly because bool is a subclass of int.
+        if isinstance(self.target, bool):
+            raise ConstraintError(
+                f"LinearConstraint target must be a float, not a bool; "
+                f"got {self.target!r}"
+            )
+        if not isinstance(self.target, (int, float)):
+            raise ConstraintError(
+                f"LinearConstraint target must be a number; "
+                f"got {self.target!r} of type {type(self.target).__name__}"
+            )
+        if not math.isfinite(float(self.target)):
+            raise ConstraintError(
+                f"LinearConstraint target must be finite; " f"got {self.target!r}"
+            )
+
     @property
     def free_params(self) -> tuple[str, ...]:
         """Parameter names that are free (all except the last)."""
@@ -55,23 +278,48 @@ class LinearConstraint:
         """The parameter name that is derived from the others."""
         return self.param_names[-1]
 
-    def enforce(self, params: dict[str, torch.Tensor]) -> dict[str, torch.Tensor]:
-        """Enforce the constraint by recomputing the derived parameter.
+    def apply(
+        self,
+        params: dict[str, torch.Tensor],
+        resolver: ConstraintResolver,
+    ) -> dict[str, torch.Tensor]:
+        """Enforce the constraint on a vectorized tensor dict.
 
-        This operation is differentiable: the derived parameter's value
-        is a function of the free parameters, so autograd tracks the
-        dependency (``d(derived)/d(free_i) = -1``).
+        Computes ``derived = target - sum(free_params)`` and writes
+        the result into the location of the derived parameter. The
+        operation is differentiable end-to-end: autograd flows
+        ``-1`` gradients back to each free parameter and leaves the
+        derived slot with zero gradient.
+
+        The method mutates ``params`` in place and returns it.
+        Callers must use the return value and must not retain
+        references to individual tensors across the call, because
+        indexed writes rebind the dict entry via
+        :func:`torch.Tensor.index_put`.
 
         Parameters
         ----------
         params : dict[str, torch.Tensor]
-            Mutable parameter dictionary. Modified in-place and returned.
+            Step-time parameter dictionary, as produced by
+            :meth:`macrostat.core.parameters.Parameters.vectorize_parameters`
+            and possibly mutated by
+            :meth:`macrostat.core.behavior.Behavior.apply_parameter_shocks`.
+        resolver : ConstraintResolver
+            Resolver mapping the constraint's canonical parameter
+            names to locations in ``params``.
 
         Returns
         -------
         dict[str, torch.Tensor]
             The same dictionary with the derived parameter updated.
+
+        Raises
+        ------
+        ConstraintError
+            If any of the constraint's names are not known to the
+            resolver.
         """
-        free_sum = sum(params[name] for name in self.free_params)
-        params[self.derived_param] = free_sum.new_tensor(self.target) - free_sum
+        free_sum = sum(resolver.locate(name).read(params) for name in self.free_params)
+        new_val = free_sum.new_tensor(self.target) - free_sum
+        resolver.locate(self.derived_param).write(params, new_val)
         return params

--- a/src/macrostat/core/parameters.py
+++ b/src/macrostat/core/parameters.py
@@ -16,6 +16,8 @@ import os
 import pandas as pd
 import torch
 
+from macrostat.core.constraints import LinearConstraint
+
 logger = logging.getLogger(__name__)
 
 
@@ -64,6 +66,8 @@ class Parameters:
             self.hyper.update(new)
 
         self.verify_bounds()
+        self.verify_constraints()
+        self.enforce_constraints()
         self.verify_parameters()
 
     def __contains__(self, key: str):
@@ -230,6 +234,114 @@ class Parameters:
         """
         return {}
 
+    def get_constraints(self) -> tuple[LinearConstraint, ...]:
+        """Return parameter constraints for this model.
+
+        Override in subclasses to declare adding-up constraints.
+        Default: no constraints.
+
+        Returns
+        -------
+        tuple[LinearConstraint, ...]
+            Constraints to enforce. Order matters if a derived param
+            in one constraint is free in another (topological ordering).
+        """
+        return ()
+
+    def verify_constraints(self):
+        """Verify that declared constraints are well-formed.
+
+        Raises
+        ------
+        ValueError
+            If a parameter appears as derived in more than one constraint,
+            or if a derived parameter in one constraint appears as a free
+            parameter in another constraint, or if a constraint references
+            a parameter not in self.values.
+        """
+        constraints = self.get_constraints()
+        if not constraints:
+            return
+
+        derived_params = []
+        for c in constraints:
+            # Check all param names exist
+            for name in c.param_names:
+                if name not in self.values:
+                    raise ValueError(
+                        f"Constraint references unknown parameter '{name}'. "
+                        f"Available: {sorted(self.values.keys())}"
+                    )
+            derived_params.append(c.derived_param)
+
+        # Check no duplicate derived params
+        if len(derived_params) != len(set(derived_params)):
+            seen = set()
+            duplicates = []
+            for p in derived_params:
+                if p in seen:
+                    duplicates.append(p)
+                seen.add(p)
+            raise ValueError(
+                f"Parameter(s) {duplicates} appear as derived in multiple "
+                f"constraints. Each parameter can be derived in at most one."
+            )
+
+        # Check no derived param is free in another constraint
+        derived_set = set(derived_params)
+        for c in constraints:
+            overlap = derived_set & set(c.free_params)
+            if overlap:
+                raise ValueError(
+                    f"Parameter(s) {sorted(overlap)} are derived in one "
+                    f"constraint but appear as free in another. This creates "
+                    f"circular dependencies."
+                )
+
+        # Warn if defaults violate constraints
+        for c in constraints:
+            actual_sum = sum(self.values[name]["value"] for name in c.param_names)
+            if abs(actual_sum - c.target) > 1e-6:
+                logger.warning(
+                    "Constraint violation in defaults: sum(%s) = %.8f, "
+                    "target = %.8f. Derived parameter '%s' will be adjusted.",
+                    c.param_names,
+                    actual_sum,
+                    c.target,
+                    c.derived_param,
+                )
+
+    def enforce_constraints(self):
+        """Enforce all constraints by adjusting derived parameter values.
+
+        Modifies ``self.values[derived_param]["value"]`` in place so that
+        the adding-up constraint is satisfied. Called during ``__init__``
+        and before any export (``to_nn_parameters``, ``to_json``, etc.).
+        """
+        for c in self.get_constraints():
+            free_sum = sum(self.values[name]["value"] for name in c.free_params)
+            new_value = c.target - free_sum
+            old_value = self.values[c.derived_param]["value"]
+            if abs(old_value - new_value) > 1e-12:
+                logger.debug(
+                    "Constraint: %s adjusted from %.8g to %.8g",
+                    c.derived_param,
+                    old_value,
+                    new_value,
+                )
+            self.values[c.derived_param]["value"] = new_value
+
+    def get_free_param_names(self) -> list[str]:
+        """Return parameter names excluding derived (constrained) parameters.
+
+        Returns
+        -------
+        list[str]
+            All parameter names that are free (not derived by any constraint).
+        """
+        derived = {c.derived_param for c in self.get_constraints()}
+        return [name for name in self.values if name not in derived]
+
     def get_bounds(self):
         """Return the bounds for the parameters."""
         return {
@@ -239,6 +351,7 @@ class Parameters:
 
     def get_values(self):
         """Return the values for the parameters."""
+        self.enforce_constraints()
         return {key: info["value"] for key, info in self.values.items()}
 
     def is_equal(self, other: "Parameters"):
@@ -277,6 +390,7 @@ class Parameters:
         sphinx_math: bool
             Whether to use Sphinx math notation in the CSV file.
         """
+        self.enforce_constraints()
         par = pd.DataFrame.from_dict(self.values, orient="index").sort_index()
         par = par[["notation", "unit", "value", "lower bound", "upper bound"]]
         par.columns = ["Notation", "Unit", "Value", "Lower Bound", "Upper Bound"]
@@ -310,6 +424,7 @@ class Parameters:
         file_path: os.PathLike
             The path to the JSON file to save the parameters to.
         """
+        self.enforce_constraints()
         with open(file_path, "w") as file:
             json.dump(
                 {
@@ -321,6 +436,7 @@ class Parameters:
 
     def to_nn_parameters(self):
         """Convert the parameters to a nn.ParameterDict."""
+        self.enforce_constraints()
         vectorized = self.vectorize_parameters()
         return torch.nn.ParameterDict(vectorized)
 

--- a/src/macrostat/core/parameters.py
+++ b/src/macrostat/core/parameters.py
@@ -16,7 +16,12 @@ import os
 import pandas as pd
 import torch
 
-from macrostat.core.constraints import LinearConstraint
+from macrostat.core.constraints import (
+    ConstraintError,
+    ConstraintResolver,
+    LinearConstraint,
+    ParameterLocation,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -64,6 +69,10 @@ class Parameters:
         if hyperparameters is not None:
             new = {k: v for k, v in hyperparameters.items() if k in self.hyper}
             self.hyper.update(new)
+
+        # Lazily built on first call to get_constraint_resolver; any future
+        # mutation API that changes self.values must call _invalidate_resolver.
+        self._constraint_resolver: ConstraintResolver | None = None
 
         self.verify_bounds()
         self.verify_constraints()
@@ -240,41 +249,135 @@ class Parameters:
         Override in subclasses to declare adding-up constraints.
         Default: no constraints.
 
+        Constraints are applied in declaration order. Chaining
+        (a derived parameter in one constraint appearing as a free
+        parameter in another) is explicitly rejected by
+        :meth:`verify_constraints`.
+
         Returns
         -------
         tuple[LinearConstraint, ...]
-            Constraints to enforce. Order matters if a derived param
-            in one constraint is free in another (topological ordering).
+            Constraints to enforce on this parameter set.
         """
         return ()
+
+    def get_constraint_resolver(self) -> ConstraintResolver:
+        """Return a :class:`ConstraintResolver` for the current parameter set.
+
+        Built lazily on first call and cached on the instance. The
+        resolver maps canonical (dotted) parameter names to their
+        :class:`ParameterLocation` in the step-time tensor dict that
+        :meth:`vectorize_parameters` produces. This lets the same
+        :class:`LinearConstraint` apply to scalar, 1-D sector-indexed,
+        and 2-D sector-by-sector parameter layouts uniformly.
+
+        The build logic mirrors :meth:`vectorize_parameters`:
+
+        * ``len(parts) == 2`` and first part in ``vector_sectors`` →
+          1-D slot at ``tensor_key=parts[1]`` indexed by the sector
+          position.
+        * ``len(parts) == 3`` and first two parts in ``vector_sectors`` →
+          2-D slot at ``tensor_key=parts[2]`` indexed by the row and
+          column sector positions.
+        * Otherwise → scalar slot at ``tensor_key=name.replace(".", "_")``
+          with ``index=None``.
+
+        Returns
+        -------
+        ConstraintResolver
+            Resolver over the current parameter set.
+        """
+        if self._constraint_resolver is not None:
+            return self._constraint_resolver
+
+        if "vector_sectors" in self.hyper:
+            vsecs = sorted(self.hyper["vector_sectors"])
+        else:
+            vsecs = []
+
+        mapping: dict[str, ParameterLocation] = {}
+        for name in self.values:
+            parts = name.split(".")
+
+            if len(parts) == 2 and parts[0] in vsecs:
+                sec, par = parts
+                mapping[name] = ParameterLocation(
+                    tensor_key=par,
+                    index=(vsecs.index(sec),),
+                )
+            elif len(parts) == 3 and parts[0] in vsecs and parts[1] in vsecs:
+                rowsec, colsec, par = parts
+                mapping[name] = ParameterLocation(
+                    tensor_key=par,
+                    index=(vsecs.index(rowsec), vsecs.index(colsec)),
+                )
+            else:
+                mapping[name] = ParameterLocation(
+                    tensor_key=name.replace(".", "_"),
+                    index=None,
+                )
+
+        self._constraint_resolver = ConstraintResolver(mapping)
+        return self._constraint_resolver
+
+    def _invalidate_resolver(self) -> None:
+        """Drop the cached :class:`ConstraintResolver`.
+
+        Call from any future mutation API that changes the key set of
+        ``self.values`` or the ``vector_sectors`` hyperparameter.
+        Currently unused because parameters are effectively frozen
+        after ``__init__``.
+        """
+        self._constraint_resolver = None
 
     def verify_constraints(self):
         """Verify that declared constraints are well-formed.
 
+        Runs seven checks against the declared constraint set:
+
+        1. Every referenced parameter exists in ``self.values``.
+        2. No parameter is derived in more than one constraint.
+        3. No derived parameter appears as a free parameter in another
+           constraint (chaining is not supported).
+        4. Every referenced parameter is locatable by the resolver
+           returned from :meth:`get_constraint_resolver`. This is a
+           defensive check against divergence between the parameter
+           dictionary and the resolver build rules.
+        5. Within each constraint, all parameter locations share a
+           compatible shape class: all scalar, or all 1-D slots of the
+           same ``tensor_key``, or all 2-D slots of the same
+           ``tensor_key``. Mixed-shape constraints are rejected.
+        6. The prospective post-enforcement value of the derived
+           parameter (``target - sum(free)``) lies within its declared
+           bounds. Catches misdeclared constraints at init time rather
+           than after enforcement.
+        7. If any constraint is violated by the provided defaults, a
+           warning is logged and the derived parameter will be
+           adjusted by :meth:`enforce_constraints`.
+
         Raises
         ------
-        ValueError
-            If a parameter appears as derived in more than one constraint,
-            or if a derived parameter in one constraint appears as a free
-            parameter in another constraint, or if a constraint references
-            a parameter not in self.values.
+        ConstraintError
+            If any of checks 1-6 fail. :class:`ConstraintError`
+            subclasses :class:`ValueError`, so callers that catch
+            ``ValueError`` continue to work.
         """
         constraints = self.get_constraints()
         if not constraints:
             return
 
+        # Check 1: all referenced parameter names exist.
         derived_params = []
         for c in constraints:
-            # Check all param names exist
             for name in c.param_names:
                 if name not in self.values:
-                    raise ValueError(
+                    raise ConstraintError(
                         f"Constraint references unknown parameter '{name}'. "
                         f"Available: {sorted(self.values.keys())}"
                     )
             derived_params.append(c.derived_param)
 
-        # Check no duplicate derived params
+        # Check 2: no duplicate derived params.
         if len(derived_params) != len(set(derived_params)):
             seen = set()
             duplicates = []
@@ -282,23 +385,88 @@ class Parameters:
                 if p in seen:
                     duplicates.append(p)
                 seen.add(p)
-            raise ValueError(
+            raise ConstraintError(
                 f"Parameter(s) {duplicates} appear as derived in multiple "
                 f"constraints. Each parameter can be derived in at most one."
             )
 
-        # Check no derived param is free in another constraint
+        # Check 3: no derived param is free in another constraint.
         derived_set = set(derived_params)
         for c in constraints:
             overlap = derived_set & set(c.free_params)
             if overlap:
-                raise ValueError(
+                raise ConstraintError(
                     f"Parameter(s) {sorted(overlap)} are derived in one "
-                    f"constraint but appear as free in another. This creates "
-                    f"circular dependencies."
+                    f"constraint but appear as free in another. Chained "
+                    f"constraints are not supported."
                 )
 
-        # Warn if defaults violate constraints
+        # Check 4: every name is resolvable. Uses a fresh resolver so
+        # any divergence between the cache and the current parameter
+        # dictionary surfaces here.
+        resolver = self.get_constraint_resolver()
+        for c in constraints:
+            for name in c.param_names:
+                if name not in resolver:
+                    raise ConstraintError(
+                        f"Constraint parameter '{name}' is not resolvable "
+                        f"to a tensor slot. This usually indicates a "
+                        f"mismatch between the parameter name and the "
+                        f"vector_sectors hyperparameter."
+                    )
+
+        # Check 5: shape homogeneity within each constraint.
+        for c in constraints:
+            locs = [resolver.locate(name) for name in c.param_names]
+            scalar_locs = [loc for loc in locs if loc.index is None]
+            indexed_locs = [loc for loc in locs if loc.index is not None]
+            if scalar_locs and indexed_locs:
+                raise ConstraintError(
+                    f"Constraint {c.param_names!r} mixes scalar and "
+                    f"indexed parameter locations. All parameters in a "
+                    f"single constraint must share the same shape class."
+                )
+            if indexed_locs:
+                tensor_keys = {loc.tensor_key for loc in indexed_locs}
+                if len(tensor_keys) > 1:
+                    raise ConstraintError(
+                        f"Constraint {c.param_names!r} spans multiple "
+                        f"tensor keys {sorted(tensor_keys)!r}. All "
+                        f"indexed parameters in a single constraint "
+                        f"must live in the same tensor."
+                    )
+                index_dims = {len(loc.index) for loc in indexed_locs}
+                if len(index_dims) > 1:
+                    raise ConstraintError(
+                        f"Constraint {c.param_names!r} mixes "
+                        f"{sorted(index_dims)!r}-dimensional index "
+                        f"shapes. All parameters must share the same "
+                        f"index rank."
+                    )
+
+        # Check 6: prospective derived value lies within bounds.
+        for c in constraints:
+            free_sum = sum(self.values[name]["value"] for name in c.free_params)
+            prospective = c.target - free_sum
+            info = self.values[c.derived_param]
+            lo = info.get("lower bound")
+            hi = info.get("upper bound")
+            if lo is not None and prospective < lo:
+                raise ConstraintError(
+                    f"Constraint would drive derived parameter "
+                    f"'{c.derived_param}' to {prospective:.8g}, below "
+                    f"its lower bound {lo:.8g}. Check the free "
+                    f"parameter defaults or the constraint target."
+                )
+            if hi is not None and prospective > hi:
+                raise ConstraintError(
+                    f"Constraint would drive derived parameter "
+                    f"'{c.derived_param}' to {prospective:.8g}, above "
+                    f"its upper bound {hi:.8g}. Check the free "
+                    f"parameter defaults or the constraint target."
+                )
+
+        # Check 7: warn if defaults violate constraints.
         for c in constraints:
             actual_sum = sum(self.values[name]["value"] for name in c.param_names)
             if abs(actual_sum - c.target) > 1e-6:

--- a/src/macrostat/diff/jacobian_numerical.py
+++ b/src/macrostat/diff/jacobian_numerical.py
@@ -284,7 +284,7 @@ class JacobianNumerical(JacobianBase):
             )
 
         if param_names is None:
-            param_names = list(self.model.parameters.values.keys())
+            param_names = self.model.parameters.get_free_param_names()
 
         output_base = self.model.simulate(scenario=self.scenario)
         loss_base = loss_fn(output_base)

--- a/src/macrostat/estimation/lm.py
+++ b/src/macrostat/estimation/lm.py
@@ -289,9 +289,13 @@ class LevenbergMarquardt:
         return result
 
     def _get_parameters(self) -> dict[str, torch.Tensor]:
-        """Get current parameter values from model."""
+        """Get current free parameter values from model.
+
+        Excludes derived (constrained) parameters, which are computed
+        from free parameters via ``enforce_constraints()``.
+        """
         params = {}
-        for name in self.model.parameters.values.keys():
+        for name in self.model.parameters.get_free_param_names():
             params[name] = torch.tensor(
                 self.model.parameters.values[name]["value"],
                 dtype=torch.float64,

--- a/src/macrostat/models/GL06INSOUT/behavior.py
+++ b/src/macrostat/models/GL06INSOUT/behavior.py
@@ -1451,7 +1451,7 @@ class BehaviorGL06INSOUT(Behavior):
         -----
         - M2Demand
         """
-        self.state["M2Demand"] = torch.clamp(
+        self.state["M2Demand"] = (
             self.state["ExpectedNonCashWealth"]
             * (
                 params["WealthShareM2_Constant"]
@@ -1461,8 +1461,7 @@ class BehaviorGL06INSOUT(Behavior):
                 * self.state["ExpectedReturnOnBonds"]
             )
             + params["WealthShareM2_Income"]
-            * self.state["NominalExpectedDisposableIncome"],
-            min=0.0,
+            * self.state["NominalExpectedDisposableIncome"]
         )
 
     def bills_demand(
@@ -1487,7 +1486,7 @@ class BehaviorGL06INSOUT(Behavior):
         -----
         - BillsDemand
         """
-        self.state["BillsDemand"] = torch.clamp(
+        self.state["BillsDemand"] = (
             self.state["ExpectedNonCashWealth"]
             * (
                 params["WealthShareBills_Constant"]
@@ -1497,8 +1496,7 @@ class BehaviorGL06INSOUT(Behavior):
                 * self.state["ExpectedReturnOnBonds"]
             )
             + params["WealthShareBills_Income"]
-            * self.state["NominalExpectedDisposableIncome"],
-            min=0.0,
+            * self.state["NominalExpectedDisposableIncome"]
         )
 
     def bonds_demand(
@@ -1537,13 +1535,10 @@ class BehaviorGL06INSOUT(Behavior):
         )
         bp = self.state["BondPrice"]
         safe_bp = torch.where(bp > 0, bp, torch.ones_like(bp))
-        self.state["BondsDemand"] = torch.clamp(
-            torch.where(
-                bp > 0,
-                value_demand / safe_bp,
-                torch.zeros_like(bp),
-            ),
-            min=0.0,
+        self.state["BondsDemand"] = torch.where(
+            bp > 0,
+            value_demand / safe_bp,
+            torch.zeros_like(bp),
         )
 
     def m1_demand_tentative(

--- a/src/macrostat/models/GL06INSOUT/parameters.py
+++ b/src/macrostat/models/GL06INSOUT/parameters.py
@@ -13,6 +13,7 @@ __maintainer__ = ["Karl Naumann-Woleske"]
 
 import logging
 
+from macrostat.core.constraints import LinearConstraint
 from macrostat.core.parameters import Parameters
 
 logger = logging.getLogger(__name__)
@@ -407,6 +408,68 @@ class ParametersGL06INSOUT(Parameters):
                 "value": -0.06,
             },
         }
+
+    def get_constraints(self) -> tuple[LinearConstraint, ...]:
+        """Return adding-up constraints for the Tobin portfolio matrix.
+
+        The GL06INSOUT model has a 4-asset Tobin portfolio allocation
+        (M1, M2, Bills, Bonds). The Godley-Lavoie adding-up constraints
+        require constant shares to sum to 1, and each rate/income
+        sensitivity column to sum to 0. M1 (cash) is the buffer-stock
+        residual asset.
+        """
+        return (
+            # Constants: lambda_20 + lambda_30 + lambda_40 + lambda_10 = 1
+            LinearConstraint(
+                param_names=(
+                    "WealthShareM2_Constant",
+                    "WealthShareBills_Constant",
+                    "WealthShareBonds_Constant",
+                    "WealthShareM1_Constant",
+                ),
+                target=1.0,
+            ),
+            # Deposit rate sensitivities sum to 0
+            LinearConstraint(
+                param_names=(
+                    "WealthShareM2_DepositRate",
+                    "WealthShareBills_DepositRate",
+                    "WealthShareBonds_DepositRate",
+                    "WealthShareM1_DepositRate",
+                ),
+                target=0.0,
+            ),
+            # Bill rate sensitivities sum to 0
+            LinearConstraint(
+                param_names=(
+                    "WealthShareM2_BillRate",
+                    "WealthShareBills_BillRate",
+                    "WealthShareBonds_BillRate",
+                    "WealthShareM1_BillRate",
+                ),
+                target=0.0,
+            ),
+            # Bond yield sensitivities sum to 0
+            LinearConstraint(
+                param_names=(
+                    "WealthShareM2_BondYield",
+                    "WealthShareBills_BondYield",
+                    "WealthShareBonds_BondYield",
+                    "WealthShareM1_BondYield",
+                ),
+                target=0.0,
+            ),
+            # Income sensitivities sum to 0
+            LinearConstraint(
+                param_names=(
+                    "WealthShareM2_Income",
+                    "WealthShareBills_Income",
+                    "WealthShareBonds_Income",
+                    "WealthShareM1_Income",
+                ),
+                target=0.0,
+            ),
+        )
 
     def get_default_hyperparameters(self):
         """Return the default hyperparameter values."""

--- a/src/macrostat/sample/sampler.py
+++ b/src/macrostat/sample/sampler.py
@@ -72,9 +72,12 @@ class BaseSampler:
 
         # Boundaries for the parameters
         self.logspace = logspace
-        self.bounds = (
-            bounds if bounds is not None else self.model.parameters.get_bounds()
-        )
+        if bounds is not None:
+            self.bounds = bounds
+        else:
+            all_bounds = self.model.parameters.get_bounds()
+            free_names = set(self.model.parameters.get_free_param_names())
+            self.bounds = {k: v for k, v in all_bounds.items() if k in free_names}
         self.verify_bounds(self.bounds)
 
         # Computation parameters

--- a/tests/core/behavior_test.py
+++ b/tests/core/behavior_test.py
@@ -10,9 +10,16 @@ __maintainer__ = ["Karl Naumann-Woleske"]
 
 import pytest
 import torch
-from conftest import MockParameters, MockScenarios, MockVariables
+from conftest import (
+    MockParameters,
+    MockScenarios,
+    MockVariables,
+    VectorMockParameters,
+    VectorMockScenarios,
+    VectorMockVariables,
+)
 
-from macrostat.core import Behavior, Variables
+from macrostat.core import Behavior, LinearConstraint, Parameters, Variables
 
 
 class TestBehavior:
@@ -252,3 +259,143 @@ class TestBehavior:
 
         with pytest.raises(NotImplementedError):
             behavior_instance.step(t=0, scenario={})
+
+
+class ConstrainedScalarParameters(Parameters):
+    """Parameters with a scalar sum-to-1 constraint on three entries."""
+
+    def get_default_parameters(self):
+        return {
+            "a": {
+                "value": 0.3,
+                "lower bound": -1.0,
+                "upper bound": 1.0,
+                "unit": ".",
+                "notation": "a",
+            },
+            "b": {
+                "value": 0.5,
+                "lower bound": -1.0,
+                "upper bound": 1.0,
+                "unit": ".",
+                "notation": "b",
+            },
+            "c": {
+                "value": 0.2,
+                "lower bound": -1.0,
+                "upper bound": 1.0,
+                "unit": ".",
+                "notation": "c",
+            },
+        }
+
+    def get_constraints(self):
+        return (LinearConstraint(param_names=("a", "b", "c"), target=1.0),)
+
+
+class ConstrainedScalarVariables(Variables):
+    def get_default_variables(self) -> dict:
+        return {
+            "output": {
+                "notation": r"Y",
+                "unit": "USD",
+                "history": 0,
+                "sectors": ["Household"],
+                "sfc": [("Index", "Household")],
+            }
+        }
+
+
+class TestBehaviorConstraints:
+    """Step-time constraint enforcement through ``apply_parameter_shocks``."""
+
+    def _make_behavior(self, ParamCls, VarCls, ScnCls):
+        p = ParamCls()
+        return Behavior(
+            parameters=p,
+            scenarios=ScnCls(parameters=p),
+            variables=VarCls(parameters=p),
+            scenario=0,
+        )
+
+    def test_does_not_snapshot_constraints(self):
+        """Behavior holds the Parameters instance, not a frozen list."""
+        b = self._make_behavior(
+            ConstrainedScalarParameters,
+            ConstrainedScalarVariables,
+            MockScenarios,
+        )
+        assert not hasattr(b, "constraints")
+        assert b.parameters is not None
+
+    def test_scalar_constraint_survives_shock(self):
+        """Adding-up holds after a free parameter is shocked."""
+        b = self._make_behavior(
+            ConstrainedScalarParameters,
+            ConstrainedScalarVariables,
+            MockScenarios,
+        )
+        scenario = {"a_add": torch.tensor(0.2)}
+        params = b.apply_parameter_shocks(t=0, scenario=scenario)
+        total = params["a"] + params["b"] + params["c"]
+        assert torch.isclose(total, torch.tensor(1.0), atol=1e-6)
+        # Derived parameter absorbed the shock: c = 1 - 0.5 - 0.5 = 0
+        assert torch.isclose(params["c"], torch.tensor(0.0), atol=1e-6)
+
+    def test_scalar_constraint_noop_without_shock(self):
+        """With no shocks, derived value equals the init-time value."""
+        b = self._make_behavior(
+            ConstrainedScalarParameters,
+            ConstrainedScalarVariables,
+            MockScenarios,
+        )
+        params = b.apply_parameter_shocks(t=0, scenario={})
+        total = params["a"] + params["b"] + params["c"]
+        assert torch.isclose(total, torch.tensor(1.0), atol=1e-6)
+
+    def test_vector_constraint_survives_shock(self):
+        """1-D sector-indexed constraint holds after a sectoral shock."""
+        b = self._make_behavior(
+            VectorMockParameters,
+            VectorMockVariables,
+            VectorMockScenarios,
+        )
+        # Initial: Household=0.6, Firm=0.4, summing to 1.
+        # Shock one sector's multiplier; derived sector (sorted order
+        # makes Household the second entry) absorbs it.
+        scenario = {"Firm_Share_multiply": torch.tensor(0.5)}
+        params = b.apply_parameter_shocks(t=0, scenario=scenario)
+        # Share is 1-D with two sectors; must sum to 1 after apply.
+        assert torch.isclose(params["Share"].sum(), torch.tensor(1.0), atol=1e-6)
+
+    def test_vector_constraint_grad_flow(self):
+        """Gradient from derived slot flows to free slot with sign -1."""
+        p = VectorMockParameters()
+        # Make the free parameter a leaf that requires grad. Identify it
+        # by asking the resolver which slot the derived parameter is in:
+        # free_params[0] is the other one.
+        constraint = p.get_constraints()[0]
+        resolver = p.get_constraint_resolver()
+        free_loc = resolver.locate(constraint.free_params[0])
+        derived_loc = resolver.locate(constraint.derived_param)
+        assert free_loc.tensor_key == "Share"
+        assert derived_loc.tensor_key == "Share"
+
+        # Build a fresh params dict with a grad-tracking free slot.
+        share = torch.zeros(2, requires_grad=False)
+        free_leaf = torch.tensor(0.6, requires_grad=True)
+        # Compose via stack so the resulting tensor is non-leaf and
+        # tracks gradients into free_leaf.
+        if free_loc.index == (0,):
+            share = torch.stack([free_leaf, torch.zeros(())])
+        else:
+            share = torch.stack([torch.zeros(()), free_leaf])
+        params = {"Share": share}
+        constraint.apply(params, resolver)
+
+        # Loss depends only on the derived slot; grad should flow back
+        # to the free leaf with value -1.
+        loss = params["Share"][derived_loc.index[0]]
+        loss.backward()
+        assert free_leaf.grad is not None
+        assert torch.isclose(free_leaf.grad, torch.tensor(-1.0))

--- a/tests/core/conftest.py
+++ b/tests/core/conftest.py
@@ -8,7 +8,7 @@ __license__ = "MIT"
 __version__ = "0.1.0"
 __maintainer__ = ["Karl Naumann-Woleske"]
 
-from macrostat.core import Model, Parameters, Scenarios, Variables
+from macrostat.core import LinearConstraint, Model, Parameters, Scenarios, Variables
 
 
 class MockScenarios(Scenarios):
@@ -72,3 +72,79 @@ class MockModel(Model):
     parameters = MockParameters()
     variables = MockVariables(parameters=parameters)
     scenarios = MockScenarios(parameters=parameters)
+
+
+class VectorMockParameters(Parameters):
+    """Mock parameters with a 1-D sector-indexed constraint.
+
+    Two sectors (``Household`` and ``Firm``), one sector-indexed
+    parameter ``Share``, constrained to sum to 1. Exercises the
+    1-D resolver path through init and step time uniformly.
+    """
+
+    def get_default_parameters(self):
+        return {
+            "Household.Share": {
+                "value": 0.6,
+                "lower bound": 0.0,
+                "upper bound": 1.0,
+                "unit": ".",
+                "notation": r"s_H",
+            },
+            "Firm.Share": {
+                "value": 0.4,
+                "lower bound": 0.0,
+                "upper bound": 1.0,
+                "unit": ".",
+                "notation": r"s_F",
+            },
+        }
+
+    def get_default_hyperparameters(self):
+        return {
+            "timesteps": 100,
+            "timesteps_initialization": 10,
+            "scenario_trigger": 0,
+            "seed": 42,
+            "device": "cpu",
+            "requires_grad": False,
+            "vector_sectors": ["Household", "Firm"],
+        }
+
+    def get_constraints(self):
+        return (
+            LinearConstraint(
+                param_names=("Household.Share", "Firm.Share"),
+                target=1.0,
+            ),
+        )
+
+
+class VectorMockVariables(Variables):
+    """Minimal variables for a two-sector vector-capable mock model."""
+
+    def get_default_variables(self) -> dict:
+        return {
+            "output": {
+                "notation": r"Y",
+                "unit": "USD",
+                "history": 0,
+                "sectors": ["Household", "Firm"],
+                "sfc": [("Index", "Household"), ("Index", "Firm")],
+            }
+        }
+
+
+class VectorMockScenarios(Scenarios):
+    """Scenarios for the two-sector vector-capable mock model."""
+
+    def get_default_scenario_values(self) -> dict:
+        return {"shock": 0.0}
+
+
+class VectorMockModel(Model):
+    """Two-sector mock model with a 1-D adding-up constraint on ``Share``."""
+
+    parameters = VectorMockParameters()
+    variables = VectorMockVariables(parameters=parameters)
+    scenarios = VectorMockScenarios(parameters=parameters)

--- a/tests/core/constraints_test.py
+++ b/tests/core/constraints_test.py
@@ -1,0 +1,363 @@
+"""
+pytest code for macrostat.core.constraints
+
+Covers ParameterLocation, ConstraintResolver, LinearConstraint
+validation, and LinearConstraint.apply across scalar, 1-D and 2-D paths.
+"""
+
+__author__ = ["Karl Naumann-Woleske"]
+__credits__ = ["Karl Naumann-Woleske"]
+__license__ = "MIT"
+__maintainer__ = ["Karl Naumann-Woleske"]
+
+import math
+
+import pytest
+import torch
+
+from macrostat.core.constraints import (
+    ConstraintError,
+    ConstraintResolver,
+    LinearConstraint,
+    ParameterLocation,
+)
+
+# ----------------------------------------------------------------------
+# ParameterLocation
+# ----------------------------------------------------------------------
+
+
+class TestParameterLocation:
+    """Read/write semantics for scalar, 1-D and 2-D slots."""
+
+    def test_scalar_read(self):
+        loc = ParameterLocation(tensor_key="TaxRate", index=None)
+        params = {"TaxRate": torch.tensor(0.2)}
+        assert loc.read(params).item() == pytest.approx(0.2)
+
+    def test_scalar_write(self):
+        loc = ParameterLocation(tensor_key="TaxRate", index=None)
+        params = {"TaxRate": torch.tensor(0.2)}
+        loc.write(params, torch.tensor(0.5))
+        assert params["TaxRate"].item() == pytest.approx(0.5)
+
+    def test_1d_read(self):
+        loc = ParameterLocation(tensor_key="Share", index=(1,))
+        params = {"Share": torch.tensor([0.3, 0.4, 0.3])}
+        assert loc.read(params).item() == pytest.approx(0.4)
+
+    def test_1d_write_out_of_place(self):
+        loc = ParameterLocation(tensor_key="Share", index=(1,))
+        base = torch.tensor([0.3, 0.4, 0.3])
+        params = {"Share": base}
+        loc.write(params, torch.tensor(0.6))
+        # index_put is out-of-place; the original tensor is untouched
+        assert base[1].item() == pytest.approx(0.4)
+        assert params["Share"][1].item() == pytest.approx(0.6)
+        # other entries preserved
+        assert params["Share"][0].item() == pytest.approx(0.3)
+        assert params["Share"][2].item() == pytest.approx(0.3)
+
+    def test_2d_write(self):
+        loc = ParameterLocation(tensor_key="Flow", index=(0, 1))
+        base = torch.zeros(2, 2)
+        params = {"Flow": base}
+        loc.write(params, torch.tensor(0.7))
+        assert params["Flow"][0, 1].item() == pytest.approx(0.7)
+        # other cells still zero
+        assert params["Flow"][0, 0].item() == 0.0
+        assert params["Flow"][1, 0].item() == 0.0
+        assert params["Flow"][1, 1].item() == 0.0
+
+    def test_1d_write_is_differentiable(self):
+        """Critical path: autograd flows through index_put."""
+        loc = ParameterLocation(tensor_key="Share", index=(1,))
+        base = torch.tensor([0.3, 0.4, 0.3], requires_grad=True)
+        params = {"Share": base}
+        new_val = torch.tensor(0.6, requires_grad=True)
+        loc.write(params, new_val)
+        # scalar loss depends only on the derived slot
+        loss = params["Share"][1] * 2.0
+        loss.backward()
+        # Gradient flows to new_val, not to the old base[1]
+        assert new_val.grad is not None
+        assert new_val.grad.item() == pytest.approx(2.0)
+
+    def test_1d_write_dtype_float64(self):
+        """Device/dtype path: the write must inherit the base tensor's dtype.
+
+        Catches the bug where torch.tensor([i], dtype=torch.long) is
+        built without a device argument.
+        """
+        loc = ParameterLocation(tensor_key="Share", index=(1,))
+        base = torch.tensor([0.3, 0.4, 0.3], dtype=torch.float64)
+        params = {"Share": base}
+        new_val = torch.tensor(0.6, dtype=torch.float64)
+        loc.write(params, new_val)
+        assert params["Share"].dtype == torch.float64
+        assert params["Share"][1].item() == pytest.approx(0.6)
+
+
+# ----------------------------------------------------------------------
+# ConstraintResolver
+# ----------------------------------------------------------------------
+
+
+class TestConstraintResolver:
+    """Resolver lookup and error messages."""
+
+    def test_locate_known(self):
+        loc = ParameterLocation(tensor_key="TaxRate", index=None)
+        r = ConstraintResolver({"TaxRate": loc})
+        assert r.locate("TaxRate") is loc
+
+    def test_locate_unknown_raises(self):
+        r = ConstraintResolver({"TaxRate": ParameterLocation("TaxRate", None)})
+        with pytest.raises(ConstraintError, match="Unknown constraint parameter"):
+            r.locate("Missing")
+
+    def test_contains(self):
+        r = ConstraintResolver({"TaxRate": ParameterLocation("TaxRate", None)})
+        assert "TaxRate" in r
+        assert "Missing" not in r
+
+    def test_len(self):
+        r = ConstraintResolver(
+            {
+                "a": ParameterLocation("a", None),
+                "b": ParameterLocation("b", None),
+            }
+        )
+        assert len(r) == 2
+
+    def test_resolver_is_not_aliased(self):
+        """Mutating the input mapping after construction must not affect it."""
+        src = {"a": ParameterLocation("a", None)}
+        r = ConstraintResolver(src)
+        src["b"] = ParameterLocation("b", None)
+        assert "b" not in r
+
+
+# ----------------------------------------------------------------------
+# LinearConstraint.__post_init__
+# ----------------------------------------------------------------------
+
+
+class TestLinearConstraintPostInit:
+    """Construction-time validation."""
+
+    def test_accepts_valid(self):
+        c = LinearConstraint(param_names=("a", "b", "c"), target=1.0)
+        assert c.free_params == ("a", "b")
+        assert c.derived_param == "c"
+        assert c.target == 1.0
+
+    def test_coerces_list_to_tuple(self):
+        c = LinearConstraint(param_names=["a", "b"], target=0.0)
+        assert c.param_names == ("a", "b")
+        assert isinstance(c.param_names, tuple)
+
+    def test_rejects_too_few_names(self):
+        with pytest.raises(ConstraintError, match="at least two"):
+            LinearConstraint(param_names=("a",), target=1.0)
+
+    def test_rejects_empty_names(self):
+        with pytest.raises(ConstraintError, match="at least two"):
+            LinearConstraint(param_names=(), target=1.0)
+
+    def test_rejects_duplicate_names(self):
+        with pytest.raises(ConstraintError, match="unique"):
+            LinearConstraint(param_names=("a", "b", "a"), target=1.0)
+
+    def test_rejects_non_string_name(self):
+        with pytest.raises(ConstraintError, match="strings"):
+            LinearConstraint(param_names=("a", 2), target=1.0)
+
+    def test_rejects_non_sequence_param_names(self):
+        with pytest.raises(ConstraintError, match="sequence"):
+            LinearConstraint(param_names=42, target=1.0)
+
+    def test_rejects_bool_target(self):
+        with pytest.raises(ConstraintError, match="bool"):
+            LinearConstraint(param_names=("a", "b"), target=True)
+
+    def test_rejects_non_numeric_target(self):
+        with pytest.raises(ConstraintError, match="number"):
+            LinearConstraint(param_names=("a", "b"), target="1.0")
+
+    def test_rejects_nan_target(self):
+        with pytest.raises(ConstraintError, match="finite"):
+            LinearConstraint(param_names=("a", "b"), target=math.nan)
+
+    def test_rejects_inf_target(self):
+        with pytest.raises(ConstraintError, match="finite"):
+            LinearConstraint(param_names=("a", "b"), target=math.inf)
+
+    def test_accepts_int_target(self):
+        c = LinearConstraint(param_names=("a", "b"), target=1)
+        assert c.target == 1
+
+
+# ----------------------------------------------------------------------
+# LinearConstraint.apply
+# ----------------------------------------------------------------------
+
+
+def _scalar_resolver(*names):
+    return ConstraintResolver(
+        {name: ParameterLocation(tensor_key=name, index=None) for name in names}
+    )
+
+
+class TestLinearConstraintApply:
+    """End-to-end constraint enforcement across all paths."""
+
+    def test_apply_scalar_path(self):
+        c = LinearConstraint(("a", "b", "c"), target=1.0)
+        resolver = _scalar_resolver("a", "b", "c")
+        params = {
+            "a": torch.tensor(0.3),
+            "b": torch.tensor(0.2),
+            "c": torch.tensor(0.99),  # will be overwritten
+        }
+        c.apply(params, resolver)
+        assert params["c"].item() == pytest.approx(0.5)
+
+    def test_apply_scalar_differentiable(self):
+        c = LinearConstraint(("a", "b", "c"), target=1.0)
+        resolver = _scalar_resolver("a", "b", "c")
+        a = torch.tensor(0.3, requires_grad=True)
+        b = torch.tensor(0.2, requires_grad=True)
+        params = {"a": a, "b": b, "c": torch.tensor(0.5)}
+        c.apply(params, resolver)
+        # downstream loss depends on derived parameter
+        loss = 4.0 * params["c"]
+        loss.backward()
+        # d(loss)/d(a) = d(loss)/d(c) * d(c)/d(a) = 4 * (-1) = -4
+        assert a.grad.item() == pytest.approx(-4.0)
+        assert b.grad.item() == pytest.approx(-4.0)
+
+    def test_apply_1d_path(self):
+        """1-D constraint: residual sector slot gets recomputed."""
+        c = LinearConstraint(
+            ("Household.Share", "Firm.Share", "Bank.Share"),
+            target=1.0,
+        )
+        # Three sectors, one free per free name, last is derived.
+        # tensor_key is "Share" with sector indices 0/1/2.
+        resolver = ConstraintResolver(
+            {
+                "Household.Share": ParameterLocation("Share", (0,)),
+                "Firm.Share": ParameterLocation("Share", (1,)),
+                "Bank.Share": ParameterLocation("Share", (2,)),
+            }
+        )
+        params = {"Share": torch.tensor([0.4, 0.2, 0.99])}
+        c.apply(params, resolver)
+        # Bank.Share = 1.0 - 0.4 - 0.2 = 0.4
+        assert params["Share"][2].item() == pytest.approx(0.4)
+        assert params["Share"].sum().item() == pytest.approx(1.0)
+
+    def test_apply_1d_autograd_correctness(self):
+        """The critical test: derived gradient is zero, free gradients are -dL/d(derived).
+
+        Build a 1-D Share tensor from leaf tensors via index_put, apply
+        the constraint, then take a scalar loss depending on the
+        derived slot and check that autograd routes the gradient back
+        to the free slots with exactly the expected sign and magnitude.
+        """
+        # Build Share tensor from free leaves so it tracks gradients
+        free_h = torch.tensor(0.4, requires_grad=True)
+        free_f = torch.tensor(0.2, requires_grad=True)
+        # Derived starts as zero placeholder; apply will overwrite
+        zero = torch.zeros(())
+        # Compose via stack so the whole tensor is on the graph
+        share = torch.stack([free_h, free_f, zero])
+        params = {"Share": share}
+        resolver = ConstraintResolver(
+            {
+                "Household.Share": ParameterLocation("Share", (0,)),
+                "Firm.Share": ParameterLocation("Share", (1,)),
+                "Bank.Share": ParameterLocation("Share", (2,)),
+            }
+        )
+        c = LinearConstraint(
+            ("Household.Share", "Firm.Share", "Bank.Share"), target=1.0
+        )
+        c.apply(params, resolver)
+
+        # Loss depends only on the derived slot.
+        loss = 3.0 * params["Share"][2]
+        loss.backward()
+
+        # d(loss)/d(free_h) = 3 * d(derived)/d(free_h) = 3 * (-1) = -3
+        assert free_h.grad.item() == pytest.approx(-3.0)
+        assert free_f.grad.item() == pytest.approx(-3.0)
+
+    def test_apply_2d_path(self):
+        """2-D constraint: one row's derived cell recomputed."""
+        c = LinearConstraint(
+            (
+                "Household.Firm.Flow",
+                "Household.Bank.Flow",
+                "Household.Household.Flow",
+            ),
+            target=1.0,
+        )
+        resolver = ConstraintResolver(
+            {
+                "Household.Firm.Flow": ParameterLocation("Flow", (0, 1)),
+                "Household.Bank.Flow": ParameterLocation("Flow", (0, 2)),
+                "Household.Household.Flow": ParameterLocation("Flow", (0, 0)),
+            }
+        )
+        flow = torch.zeros(3, 3)
+        flow[0, 1] = 0.3
+        flow[0, 2] = 0.2
+        params = {"Flow": flow}
+        c.apply(params, resolver)
+        assert params["Flow"][0, 0].item() == pytest.approx(0.5)
+        # Other rows untouched
+        assert params["Flow"][1, :].sum().item() == 0.0
+
+    def test_apply_mixed_scalar_and_indexed_free_params(self):
+        """Arithmetic works even when free params have different location shapes.
+
+        Note: higher-level verify_constraints is expected to reject
+        this case because mixed-shape constraints are rarely what the
+        user wants. But the low-level apply is agnostic and should not
+        crash if fed one; this test documents that behavior.
+        """
+        c = LinearConstraint(("Global", "Local.X", "Local.Y"), target=2.0)
+        resolver = ConstraintResolver(
+            {
+                "Global": ParameterLocation("Global", None),
+                "Local.X": ParameterLocation("Local", (0,)),
+                "Local.Y": ParameterLocation("Local", (1,)),
+            }
+        )
+        params = {
+            "Global": torch.tensor(1.0),
+            "Local": torch.tensor([0.5, 0.0]),
+        }
+        c.apply(params, resolver)
+        # Local[1] (derived) = 2.0 - 1.0 - 0.5 = 0.5
+        assert params["Local"][1].item() == pytest.approx(0.5)
+
+    def test_apply_unknown_name_raises(self):
+        c = LinearConstraint(("a", "b", "c"), target=1.0)
+        resolver = _scalar_resolver("a", "b")  # "c" missing
+        params = {"a": torch.tensor(0.3), "b": torch.tensor(0.2)}
+        with pytest.raises(ConstraintError, match="Unknown constraint parameter"):
+            c.apply(params, resolver)
+
+    def test_apply_returns_dict(self):
+        c = LinearConstraint(("a", "b", "c"), target=1.0)
+        resolver = _scalar_resolver("a", "b", "c")
+        params = {
+            "a": torch.tensor(0.3),
+            "b": torch.tensor(0.2),
+            "c": torch.tensor(0.0),
+        }
+        result = c.apply(params, resolver)
+        assert result is params

--- a/tests/core/parameters_test.py
+++ b/tests/core/parameters_test.py
@@ -14,7 +14,7 @@ import logging
 import pytest
 import torch
 
-from macrostat.core import BoundaryError, Parameters
+from macrostat.core import BoundaryError, LinearConstraint, Parameters
 
 
 @pytest.fixture
@@ -455,3 +455,262 @@ class TestParameters:
         """Test comparison with non-Parameters object"""
         with pytest.raises(AttributeError):
             mock_parameters.is_equal("not a Parameters object")
+
+
+class ConstrainedParameters(Parameters):
+    """Mock parameters with a sum-to-1 constraint."""
+
+    def get_default_parameters(self):
+        return {
+            "a": {
+                "value": 0.3,
+                "lower bound": -1.0,
+                "upper bound": 1.0,
+                "unit": ".",
+                "notation": "a",
+            },
+            "b": {
+                "value": 0.5,
+                "lower bound": -1.0,
+                "upper bound": 1.0,
+                "unit": ".",
+                "notation": "b",
+            },
+            "c": {
+                "value": 0.2,
+                "lower bound": -1.0,
+                "upper bound": 1.0,
+                "unit": ".",
+                "notation": "c",
+            },
+        }
+
+    def get_constraints(self):
+        return (LinearConstraint(param_names=("a", "b", "c"), target=1.0),)
+
+
+class TestConstraints:
+    """Tests for the LinearConstraint system."""
+
+    def test_get_constraints_default_empty(self):
+        """Base Parameters returns no constraints."""
+        p = Parameters()
+        assert p.get_constraints() == ()
+
+    def test_get_constraints_returns_tuple(self):
+        """Constrained parameters return a tuple of LinearConstraint."""
+        p = ConstrainedParameters()
+        constraints = p.get_constraints()
+        assert len(constraints) == 1
+        assert isinstance(constraints[0], LinearConstraint)
+
+    def test_linear_constraint_properties(self):
+        """Test free_params and derived_param properties."""
+        c = LinearConstraint(param_names=("a", "b", "c"), target=1.0)
+        assert c.free_params == ("a", "b")
+        assert c.derived_param == "c"
+
+    def test_enforce_constraints_adjusts_derived(self):
+        """Enforce adjusts derived param to satisfy constraint."""
+        p = ConstrainedParameters()
+        # Manually break the constraint
+        p.values["a"]["value"] = 0.6
+        p.enforce_constraints()
+        # c should be 1.0 - 0.6 - 0.5 = -0.1
+        assert abs(p.values["c"]["value"] - (-0.1)) < 1e-12
+
+    def test_enforce_constraints_noop_when_satisfied(self):
+        """Enforce does nothing when constraint is already satisfied."""
+        p = ConstrainedParameters()
+        old_c = p.values["c"]["value"]
+        p.enforce_constraints()
+        assert p.values["c"]["value"] == old_c
+
+    def test_init_enforces_constraints(self):
+        """Constraints are enforced during __init__."""
+        p = ConstrainedParameters()
+        # Mutate a free param after init, then re-enforce
+        p.values["a"]["value"] = 0.7
+        p.values["b"]["value"] = 0.1
+        p.enforce_constraints()
+        # c should be adjusted to 1.0 - 0.7 - 0.1 = 0.2
+        assert abs(p["c"] - 0.2) < 1e-12
+
+    def test_verify_constraints_duplicate_derived_raises(self):
+        """Error when same param is derived in two constraints."""
+
+        class BadParams(Parameters):
+            def get_default_parameters(self):
+                return {
+                    "a": {
+                        "value": 0.5,
+                        "lower bound": -1.0,
+                        "upper bound": 1.0,
+                        "unit": ".",
+                        "notation": "a",
+                    },
+                    "b": {
+                        "value": 0.3,
+                        "lower bound": -1.0,
+                        "upper bound": 1.0,
+                        "unit": ".",
+                        "notation": "b",
+                    },
+                    "c": {
+                        "value": 0.2,
+                        "lower bound": -1.0,
+                        "upper bound": 1.0,
+                        "unit": ".",
+                        "notation": "c",
+                    },
+                }
+
+            def get_constraints(self):
+                return (
+                    LinearConstraint(param_names=("a", "c"), target=1.0),
+                    LinearConstraint(param_names=("b", "c"), target=0.0),
+                )
+
+        with pytest.raises(ValueError, match="derived in multiple"):
+            BadParams()
+
+    def test_verify_constraints_derived_as_free_raises(self):
+        """Error when derived param in one constraint is free in another."""
+
+        class BadParams(Parameters):
+            def get_default_parameters(self):
+                return {
+                    "a": {
+                        "value": 0.5,
+                        "lower bound": -1.0,
+                        "upper bound": 1.0,
+                        "unit": ".",
+                        "notation": "a",
+                    },
+                    "b": {
+                        "value": 0.3,
+                        "lower bound": -1.0,
+                        "upper bound": 1.0,
+                        "unit": ".",
+                        "notation": "b",
+                    },
+                    "c": {
+                        "value": 0.2,
+                        "lower bound": -1.0,
+                        "upper bound": 1.0,
+                        "unit": ".",
+                        "notation": "c",
+                    },
+                    "d": {
+                        "value": 0.0,
+                        "lower bound": -1.0,
+                        "upper bound": 1.0,
+                        "unit": ".",
+                        "notation": "d",
+                    },
+                }
+
+            def get_constraints(self):
+                return (
+                    LinearConstraint(param_names=("a", "c"), target=1.0),
+                    LinearConstraint(param_names=("c", "d"), target=0.0),
+                )
+
+        with pytest.raises(ValueError, match="derived in one.*free in another"):
+            BadParams()
+
+    def test_verify_constraints_unknown_param_raises(self):
+        """Error when constraint references nonexistent parameter."""
+
+        class BadParams(Parameters):
+            def get_default_parameters(self):
+                return {
+                    "a": {
+                        "value": 0.5,
+                        "lower bound": 0.0,
+                        "upper bound": 1.0,
+                        "unit": ".",
+                        "notation": "a",
+                    },
+                }
+
+            def get_constraints(self):
+                return (LinearConstraint(param_names=("a", "nonexistent"), target=1.0),)
+
+        with pytest.raises(ValueError, match="unknown parameter"):
+            BadParams()
+
+    def test_verify_constraints_warns_on_violation(self, caplog):
+        """Warning when defaults don't satisfy constraint."""
+
+        class WarnParams(Parameters):
+            def get_default_parameters(self):
+                return {
+                    "a": {
+                        "value": 0.5,
+                        "lower bound": -1.0,
+                        "upper bound": 1.0,
+                        "unit": ".",
+                        "notation": "a",
+                    },
+                    "b": {
+                        "value": 0.3,
+                        "lower bound": -1.0,
+                        "upper bound": 1.0,
+                        "unit": ".",
+                        "notation": "b",
+                    },
+                    "c": {
+                        "value": 0.1,
+                        "lower bound": -1.0,
+                        "upper bound": 1.0,
+                        "unit": ".",
+                        "notation": "c",
+                    },
+                }
+
+            def get_constraints(self):
+                return (LinearConstraint(param_names=("a", "b", "c"), target=1.0),)
+
+        with caplog.at_level(logging.WARNING):
+            WarnParams()
+        assert "Constraint violation" in caplog.text
+
+    def test_get_free_param_names(self):
+        """Derived params excluded from free param names."""
+        p = ConstrainedParameters()
+        free = p.get_free_param_names()
+        assert "a" in free
+        assert "b" in free
+        assert "c" not in free
+
+    def test_get_values_enforces_constraints(self):
+        """get_values() returns constrained values even after mutation."""
+        p = ConstrainedParameters()
+        p.values["a"]["value"] = 0.7
+        vals = p.get_values()
+        assert abs(vals["a"] + vals["b"] + vals["c"] - 1.0) < 1e-12
+
+    def test_to_nn_parameters_enforces_constraints(self):
+        """to_nn_parameters() enforces before converting."""
+        p = ConstrainedParameters()
+        p.values["a"]["value"] = 0.7
+        nn_params = p.to_nn_parameters()
+        total = nn_params["a"].item() + nn_params["b"].item() + nn_params["c"].item()
+        assert abs(total - 1.0) < 1e-6
+
+    def test_enforce_differentiable(self):
+        """LinearConstraint.enforce() supports autograd."""
+        c = LinearConstraint(param_names=("a", "b", "c"), target=1.0)
+        a = torch.tensor(0.3, requires_grad=True)
+        b = torch.tensor(0.5, requires_grad=True)
+        params = {"a": a, "b": b, "c": torch.tensor(0.0)}
+        c.enforce(params)
+
+        # c = 1.0 - a - b = 0.2
+        assert torch.isclose(params["c"], torch.tensor(0.2))
+
+        # d(c)/d(a) = -1, d(c)/d(b) = -1
+        params["c"].backward()
+        assert torch.isclose(a.grad, torch.tensor(-1.0))
+        assert torch.isclose(b.grad, torch.tensor(-1.0))

--- a/tests/core/parameters_test.py
+++ b/tests/core/parameters_test.py
@@ -14,7 +14,14 @@ import logging
 import pytest
 import torch
 
-from macrostat.core import BoundaryError, LinearConstraint, Parameters
+from macrostat.core import (
+    BoundaryError,
+    ConstraintError,
+    ConstraintResolver,
+    LinearConstraint,
+    ParameterLocation,
+    Parameters,
+)
 
 
 @pytest.fixture
@@ -699,13 +706,20 @@ class TestConstraints:
         total = nn_params["a"].item() + nn_params["b"].item() + nn_params["c"].item()
         assert abs(total - 1.0) < 1e-6
 
-    def test_enforce_differentiable(self):
-        """LinearConstraint.enforce() supports autograd."""
+    def test_apply_differentiable(self):
+        """LinearConstraint.apply() supports autograd via the scalar path."""
         c = LinearConstraint(param_names=("a", "b", "c"), target=1.0)
+        resolver = ConstraintResolver(
+            {
+                "a": ParameterLocation("a", None),
+                "b": ParameterLocation("b", None),
+                "c": ParameterLocation("c", None),
+            }
+        )
         a = torch.tensor(0.3, requires_grad=True)
         b = torch.tensor(0.5, requires_grad=True)
         params = {"a": a, "b": b, "c": torch.tensor(0.0)}
-        c.enforce(params)
+        c.apply(params, resolver)
 
         # c = 1.0 - a - b = 0.2
         assert torch.isclose(params["c"], torch.tensor(0.2))
@@ -714,3 +728,263 @@ class TestConstraints:
         params["c"].backward()
         assert torch.isclose(a.grad, torch.tensor(-1.0))
         assert torch.isclose(b.grad, torch.tensor(-1.0))
+
+    # ------------------------------------------------------------------
+    # Resolver construction and caching
+    # ------------------------------------------------------------------
+
+    def test_get_constraint_resolver_caches(self):
+        """Two calls to get_constraint_resolver return the same object."""
+        p = ConstrainedParameters()
+        r1 = p.get_constraint_resolver()
+        r2 = p.get_constraint_resolver()
+        assert r1 is r2
+
+    def test_get_constraint_resolver_default_is_scalar(self):
+        """Without vector_sectors, every name resolves to a scalar slot."""
+        p = ConstrainedParameters()
+        r = p.get_constraint_resolver()
+        for name in ("a", "b", "c"):
+            loc = r.locate(name)
+            assert loc.index is None
+            assert loc.tensor_key == name
+
+    def test_get_constraint_resolver_builds_1d_for_sector_prefixed_names(self):
+        """Sector-prefixed names resolve to 1-D tensor slots."""
+
+        class VecParams(Parameters):
+            def get_default_parameters(self):
+                return {
+                    "Household.Share": {
+                        "value": 0.4,
+                        "lower bound": 0.0,
+                        "upper bound": 1.0,
+                        "unit": ".",
+                        "notation": "s_H",
+                    },
+                    "Firm.Share": {
+                        "value": 0.3,
+                        "lower bound": 0.0,
+                        "upper bound": 1.0,
+                        "unit": ".",
+                        "notation": "s_F",
+                    },
+                    "Bank.Share": {
+                        "value": 0.3,
+                        "lower bound": 0.0,
+                        "upper bound": 1.0,
+                        "unit": ".",
+                        "notation": "s_B",
+                    },
+                }
+
+            def get_default_hyperparameters(self):
+                h = super().get_default_hyperparameters()
+                h["vector_sectors"] = ["Household", "Firm", "Bank"]
+                return h
+
+        p = VecParams()
+        r = p.get_constraint_resolver()
+        # vsecs sorted: ['Bank', 'Firm', 'Household']
+        assert r.locate("Bank.Share") == ParameterLocation("Share", (0,))
+        assert r.locate("Firm.Share") == ParameterLocation("Share", (1,))
+        assert r.locate("Household.Share") == ParameterLocation("Share", (2,))
+
+    def test_get_constraint_resolver_builds_2d_for_matrix_names(self):
+        """Row-col-sector prefixed names resolve to 2-D tensor slots."""
+
+        class MatParams(Parameters):
+            def get_default_parameters(self):
+                return {
+                    "Household.Firm.Flow": {
+                        "value": 0.3,
+                        "lower bound": 0.0,
+                        "upper bound": 1.0,
+                        "unit": ".",
+                        "notation": "F_HF",
+                    },
+                    "Firm.Household.Flow": {
+                        "value": 0.2,
+                        "lower bound": 0.0,
+                        "upper bound": 1.0,
+                        "unit": ".",
+                        "notation": "F_FH",
+                    },
+                }
+
+            def get_default_hyperparameters(self):
+                h = super().get_default_hyperparameters()
+                h["vector_sectors"] = ["Household", "Firm"]
+                return h
+
+        p = MatParams()
+        r = p.get_constraint_resolver()
+        # vsecs sorted: ['Firm', 'Household']
+        assert r.locate("Household.Firm.Flow") == ParameterLocation("Flow", (1, 0))
+        assert r.locate("Firm.Household.Flow") == ParameterLocation("Flow", (0, 1))
+
+    # ------------------------------------------------------------------
+    # verify_constraints: new checks
+    # ------------------------------------------------------------------
+
+    def test_verify_constraints_rejects_derived_out_of_bounds(self):
+        """Init-time derived bounds check rejects infeasible constraint."""
+
+        class OutOfBoundsParams(Parameters):
+            def get_default_parameters(self):
+                return {
+                    "a": {
+                        "value": 0.8,
+                        "lower bound": 0.0,
+                        "upper bound": 1.0,
+                        "unit": ".",
+                        "notation": "a",
+                    },
+                    "b": {
+                        "value": 0.9,
+                        "lower bound": 0.0,
+                        "upper bound": 1.0,
+                        "unit": ".",
+                        "notation": "b",
+                    },
+                    "c": {
+                        "value": 0.0,
+                        "lower bound": 0.0,
+                        "upper bound": 1.0,
+                        "unit": ".",
+                        "notation": "c",
+                    },
+                }
+
+            def get_constraints(self):
+                # 1.0 - 0.8 - 0.9 = -0.7, below c's lower bound 0.0
+                return (LinearConstraint(("a", "b", "c"), target=1.0),)
+
+        with pytest.raises(ConstraintError, match="below its lower bound"):
+            OutOfBoundsParams()
+
+    def test_verify_constraints_rejects_derived_above_upper(self):
+        """Init-time derived bounds check rejects upper-bound violation."""
+
+        class AboveParams(Parameters):
+            def get_default_parameters(self):
+                return {
+                    "a": {
+                        "value": -1.0,
+                        "lower bound": -2.0,
+                        "upper bound": 2.0,
+                        "unit": ".",
+                        "notation": "a",
+                    },
+                    "b": {
+                        "value": -1.0,
+                        "lower bound": -2.0,
+                        "upper bound": 2.0,
+                        "unit": ".",
+                        "notation": "b",
+                    },
+                    "c": {
+                        "value": 0.0,
+                        "lower bound": 0.0,
+                        "upper bound": 1.0,
+                        "unit": ".",
+                        "notation": "c",
+                    },
+                }
+
+            def get_constraints(self):
+                # 1.0 - (-1) - (-1) = 3.0, above c's upper bound 1.0
+                return (LinearConstraint(("a", "b", "c"), target=1.0),)
+
+        with pytest.raises(ConstraintError, match="above its upper bound"):
+            AboveParams()
+
+    def test_verify_constraints_rejects_mixed_shape(self):
+        """Shape-homogeneity check rejects a constraint mixing scalar and indexed."""
+
+        class MixedShapeParams(Parameters):
+            def get_default_parameters(self):
+                return {
+                    "Global": {
+                        "value": 0.5,
+                        "lower bound": 0.0,
+                        "upper bound": 1.0,
+                        "unit": ".",
+                        "notation": "g",
+                    },
+                    "Household.Share": {
+                        "value": 0.3,
+                        "lower bound": 0.0,
+                        "upper bound": 1.0,
+                        "unit": ".",
+                        "notation": "s_H",
+                    },
+                    "Firm.Share": {
+                        "value": 0.2,
+                        "lower bound": 0.0,
+                        "upper bound": 1.0,
+                        "unit": ".",
+                        "notation": "s_F",
+                    },
+                }
+
+            def get_default_hyperparameters(self):
+                h = super().get_default_hyperparameters()
+                h["vector_sectors"] = ["Household", "Firm"]
+                return h
+
+            def get_constraints(self):
+                return (
+                    LinearConstraint(
+                        ("Global", "Household.Share", "Firm.Share"),
+                        target=1.0,
+                    ),
+                )
+
+        with pytest.raises(ConstraintError, match="mixes scalar and indexed"):
+            MixedShapeParams()
+
+    def test_verify_constraints_uses_constraint_error(self):
+        """verify_constraints raises ConstraintError (a ValueError subclass)."""
+
+        class BadParams(Parameters):
+            def get_default_parameters(self):
+                return {
+                    "a": {
+                        "value": 0.5,
+                        "lower bound": 0.0,
+                        "upper bound": 1.0,
+                        "unit": ".",
+                        "notation": "a",
+                    },
+                }
+
+            def get_constraints(self):
+                return (LinearConstraint(("a", "missing"), target=1.0),)
+
+        with pytest.raises(ConstraintError):
+            BadParams()
+        # Backward-compat: catching ValueError also works.
+        with pytest.raises(ValueError):
+            BadParams()
+
+    # ------------------------------------------------------------------
+    # Init-vs-step invariant
+    # ------------------------------------------------------------------
+
+    def test_init_vs_step_invariant(self):
+        """Post-init derived value equals post-apply value at step zero."""
+        p = ConstrainedParameters()
+        init_c = p.values["c"]["value"]
+
+        # Simulate step time: vectorize and apply the constraint freshly.
+        tensors = p.vectorize_parameters()
+        resolver = p.get_constraint_resolver()
+        constraints = p.get_constraints()
+        for constraint in constraints:
+            constraint.apply(tensors, resolver)
+
+        step_c = tensors["c"].item()
+        # float32 tensors vs float64 python floats; 1e-6 is the float32
+        # precision floor.
+        assert abs(init_c - step_c) < 1e-6

--- a/tests/models/gl06insout_test.py
+++ b/tests/models/gl06insout_test.py
@@ -474,3 +474,100 @@ def test_scenario7_higher_wage_and_rate():
         f"Scenario 7 should raise bill rate: "
         f"base={r_base.item():.4f}, shock={r_shock.item():.4f}"
     )
+
+
+# ---------------------------------------------------------------------------
+# Constraint system integration
+# ---------------------------------------------------------------------------
+
+
+def test_constraint_system_step_integration():
+    """End-to-end: the resolver and vectorizer agree on the scalar path.
+
+    GL06INSOUT declares five :class:`LinearConstraint` groups, all
+    naming the M1 slot of the Tobin portfolio matrix as the residual.
+    This test calls ``apply_parameter_shocks`` once (with no shocks)
+    and confirms that every derived parameter matches the
+    init-time-enforced value. It is the only test that pins the full
+    resolver-to-vectorizer round-trip on a production model.
+    """
+    from macrostat.models.GL06INSOUT import BehaviorGL06INSOUT
+
+    model, params, scenarios = _make_model(timesteps=100)
+    behavior = BehaviorGL06INSOUT(
+        parameters=params,
+        scenarios=scenarios,
+        variables=VariablesGL06INSOUT(parameters=params),
+        scenario=0,
+    )
+
+    shocked = behavior.apply_parameter_shocks(t=0, scenario={})
+
+    derived_names = [
+        "WealthShareM1_Constant",
+        "WealthShareM1_DepositRate",
+        "WealthShareM1_BillRate",
+        "WealthShareM1_BondYield",
+        "WealthShareM1_Income",
+    ]
+    for name in derived_names:
+        init_value = params.values[name]["value"]
+        step_value = shocked[name].item()
+        assert abs(init_value - step_value) < 1e-6, (
+            f"Init/step mismatch on {name}: "
+            f"init={init_value:.8g}, step={step_value:.8g}"
+        )
+
+    # All five adding-up identities must hold on the step-time tensors.
+    groups = {
+        "Constant": 1.0,
+        "DepositRate": 0.0,
+        "BillRate": 0.0,
+        "BondYield": 0.0,
+        "Income": 0.0,
+    }
+    for col, target in groups.items():
+        total = (
+            shocked[f"WealthShareM1_{col}"]
+            + shocked[f"WealthShareM2_{col}"]
+            + shocked[f"WealthShareBills_{col}"]
+            + shocked[f"WealthShareBonds_{col}"]
+        )
+        assert torch.isclose(
+            total, torch.tensor(target), atol=1e-6
+        ), f"Tobin {col} column does not sum to {target}: {total.item()}"
+
+
+def test_constraint_system_derived_grads_are_zero():
+    """Derived M1 parameters have zero autograd sensitivity end-to-end.
+
+    Runs a short simulation with ``requires_grad=True`` and checks
+    that no upstream loss can place gradient mass on the derived M1
+    slots, because they are recomputed residually each step.
+    """
+    from macrostat.models.GL06INSOUT import BehaviorGL06INSOUT
+
+    model, params, scenarios = _make_model(timesteps=100)
+    behavior = BehaviorGL06INSOUT(
+        parameters=params,
+        scenarios=scenarios,
+        variables=VariablesGL06INSOUT(parameters=params),
+        scenario=0,
+    )
+
+    shocked = behavior.apply_parameter_shocks(t=0, scenario={})
+    loss = sum(
+        shocked[f"WealthShareM1_{col}"]
+        for col in ("Constant", "DepositRate", "BillRate", "BondYield", "Income")
+    )
+    loss.backward()
+
+    for col in ("Constant", "DepositRate", "BillRate", "BondYield", "Income"):
+        derived = behavior.params[f"WealthShareM1_{col}"]
+        # Derived leaf has no grad because it is never read through the
+        # constraint path — the step-time value is recomputed from free
+        # params.
+        if derived.grad is not None:
+            assert (
+                derived.grad.abs().max().item() == 0.0
+            ), f"Derived parameter WealthShareM1_{col} has non-zero grad"


### PR DESCRIPTION
## Summary

Adds an opt-in parameter adding-up constraint system to MacroStat, extends it to handle naturally vector-valued parameters (sector-indexed budget shares, rate sensitivities), and documents the whole thing.

`LinearConstraint` expresses identities of the form $\sum_i p_i = T$ via residual parameterization: the last listed parameter is derived from the others, which keeps the free parameters independent and makes the derived parameter a non-leaf tensor with exactly zero autograd gradient. A typed `ConstraintResolver` maps canonical parameter names onto the step-time tensor layout so a single constraint can cover scalar, 1-D sector-indexed, and 2-D sector-by-sector parameters without touching the vectorizer. `Behavior.apply_parameter_shocks` fetches the resolver fresh on every step, so scenario shocks to free parameters propagate into the residual through `torch.Tensor.index_put` (out-of-place, differentiable).

The end-to-end promise is pinned on GL06INSOUT: all five derived M1 parameters have exactly zero autograd gradient and all five portfolio sums match their targets within 1e-6 after an unshocked step.

## What is new since the base branch

* `ConstraintError`, `ParameterLocation`, `ConstraintResolver` public surface in `macrostat.core`
* `LinearConstraint.__post_init__` validates name shape and target finiteness at construction
* `LinearConstraint.enforce` renamed to `apply(params, resolver)` with vector/matrix support via `index_put`
* `Parameters.get_constraint_resolver` (lazy, cached) + `_invalidate_resolver` hook
* `Parameters.verify_constraints` rewritten with six structural checks (unknown name, duplicate derived, chaining, resolver-resolvability, shape homogeneity, prospective-derived-within-bounds) plus the soft default-violation warning, all raising `ConstraintError`
* `Behavior` no longer snapshots the constraint list at init; step-time enforcement always matches the current `Parameters` instance
* Vector/matrix constraints section in the user guide, updated autograd demo in the notebook, chain-rejection rule replacing the stale topological-ordering caveat

## Test plan

- [x] `uv run pytest tests/core/constraints_test.py tests/core/parameters_test.py tests/core/behavior_test.py tests/models/gl06insout_test.py --override-ini="addopts="` → 145 / 145 passing
- [x] `cd docs && uv run make html` succeeds; all constraint-related warnings are the pre-existing autosummary duplicate-object pattern that already applied to `LinearConstraint` and `Parameters.*_constraints`
- [x] New file `tests/core/constraints_test.py` covers `ParameterLocation` read/write across scalar, 1-D and 2-D slots, `ConstraintResolver` lookup errors, `__post_init__` validation, and a float64 autograd correctness test that would catch device/dtype regressions on `index_put`
- [x] `TestBehaviorConstraints` covers scalar + 1-D shocks through `apply_parameter_shocks` and grad flow from a derived slot back to the free leaf with value -1
- [x] `tests/models/gl06insout_test.py` end-to-end check: all five derived M1 parameters equal their init values and all five group sums match their targets within 1e-6 after one step

## Notes for reviewers

* The branch also contains the original `a69ad7d feat(core): add LinearConstraint system for adding-up constraints` and its user guide (`54c9517`) plus an unrelated `218b4f3 refactor(GL06INSOUT): remove dead torch.clamp on portfolio demands` that had already landed on this branch. The four new commits on top (`65b0182`, `059c63a`, `a3b4ba2`, `d0d4430`) carry the vector/matrix extension, test coverage, integration test, and documentation refresh in implementation order.
* Constraints remain opt-in. Existing models that do not override `get_constraints` are unaffected; the step-time path fast-exits when the constraint list is empty.
* GL06INSOUT's five constraints are scalar, so the 1-D and 2-D resolver paths are exercised by `VectorMockParameters` in `tests/core/conftest.py` rather than by a production model.