### PR TITLE
refactor(KirmansAnts): Lamperti-only SDE with torch.Generator

### DIFF
--- a/src/macrostat/models/KirmansAnts/behavior.py
+++ b/src/macrostat/models/KirmansAnts/behavior.py
@@ -50,8 +50,8 @@ logger = logging.getLogger(__name__)
 class BehaviorKirmansAnts(Behavior):
     r"""Simulation logic for the Kirman ants SDE model.
 
-    Each ``step()`` call runs ``substeps`` Lamperti micro-steps via
-    :meth:`advance_lamperti`. ``self._torch_rng`` is a per-instance
+    Each :meth:`step` call runs ``substeps`` Lamperti micro-steps in
+    :math:`\phi`-space. ``self._torch_rng`` is a per-instance
     :class:`torch.Generator` re-seeded from ``hyper["seed"]`` at every
     :meth:`initialize` call. Each macro-step consumes exactly ``substeps``
     Gaussians from this stream, so the noise stream is aligned across the
@@ -133,95 +133,8 @@ class BehaviorKirmansAnts(Behavior):
         )
 
     def step(self, t: int, scenario: dict, params: dict | None = None, **kwargs):
-        """Advance the SDE by one macro-period.
-
-        Parameters
-        ----------
-        t : int
-            Current macro-period index.
-        scenario : dict
-            Vectorized scenario values at time t (unused; SDE is autonomous).
-        params : dict
-            Parameter values for time t with scenario shocks already applied.
-
-        Raises
-        ------
-        RuntimeError
-            If invoked while ``self.differentiable`` is True. The base class
-            normally blocks this at construction; this guard catches mutation
-            of the flag after init.
-        """
-        if self.differentiable:
-            raise RuntimeError(
-                "BehaviorKirmansAnts is non-differentiable; "
-                "self.differentiable was mutated to True after construction."
-            )
-        self.advance_lamperti(t=t, params=params)
-
-    # --- Lamperti map helpers ----------------------------------------------
-
-    @staticmethod
-    def _lamperti_forward(x: float) -> float:
-        r"""Forward Lamperti map :math:`\phi = \arcsin(2 x - 1)`."""
-        return math.asin(2.0 * x - 1.0)
-
-    @staticmethod
-    def _lamperti_inverse(phi: float) -> float:
-        r"""Inverse Lamperti map :math:`x = (1 + \sin\phi)/2`."""
-        return 0.5 * (1.0 + math.sin(phi))
-
-    @staticmethod
-    def _lamperti_drift(x: float, rho: float, mu: float) -> float:
-        r"""Drift of the Lamperti-transformed SDE evaluated at the cached :math:`x`.
-
-        Parameters
-        ----------
-        x : float
-            Current :math:`x`-space density (cached from previous inverse map).
-        rho : float
-            Spontaneous switching rate.
-        mu : float
-            Herding strength.
-
-        Returns
-        -------
-        float
-            :math:`\mu_\Phi(\phi)` evaluated at :math:`x`.
-
-        Notes
-        -----
-        Using :math:`\phi = f(x) = \arcsin(2 x - 1)` (Moran et al.\ 2020),
-        the Itô transform gives
-        :math:`\mu_\Phi = a(x) f'(x) + \tfrac{1}{2}\sigma^2(x) f''(x)`,
-        with constant-diffusion :math:`\sigma_\Phi \equiv \sqrt{2\mu}`. The
-        :math:`x`-form below is evaluated directly because :math:`x` is
-        already cached from the previous inverse map.
-
-        Equations
-        ---------
-        .. math::
-            \begin{align}
-                \mu_\Phi(\phi)
-                  = -(2\rho - \mu)\tan(\phi)
-                  = -\,\frac{(2\rho - \mu)\,(2 x - 1)}{2\sqrt{x(1 - x)}}.
-            \end{align}
-        """
-        return -(2.0 * rho - mu) * (2.0 * x - 1.0) / (2.0 * math.sqrt(x * (1.0 - x)))
-
-    # --- integrator --------------------------------------------------------
-
-    def advance_lamperti(self, t: int, params: dict):
         r"""Run ``substeps`` Euler-Maruyama micro-steps in Lamperti space.
 
-        Parameters
-        ----------
-        t : int
-            Macro-period index.
-        params : dict
-            Parameter values at time t.
-
-        Notes
-        -----
         Uses the Lamperti transform :math:`\phi = \arcsin(2 x - 1)` from
         Moran, Fosset, Benzaquen, Bouchaud (2020). The diffusion in
         :math:`\phi` is constant :math:`= \sqrt{2\mu}`, so Euler-Maruyama in
@@ -239,6 +152,22 @@ class BehaviorKirmansAnts(Behavior):
         ``_micro_trajectory`` stores :math:`x` (not :math:`\phi`); the
         inverse map is applied at every substep so downstream consumers stay
         method-agnostic.
+
+        Parameters
+        ----------
+        t : int
+            Current macro-period index.
+        scenario : dict
+            Vectorized scenario values at time t (unused; SDE is autonomous).
+        params : dict
+            Parameter values for time t with scenario shocks already applied.
+
+        Raises
+        ------
+        RuntimeError
+            If invoked while ``self.differentiable`` is True. The base class
+            normally blocks this at construction; this guard catches mutation
+            of the flag after init.
 
         Equations
         ---------
@@ -265,6 +194,16 @@ class BehaviorKirmansAnts(Behavior):
         -----
         - density
         """
+        if self.differentiable:
+            raise RuntimeError(
+                "BehaviorKirmansAnts is non-differentiable; "
+                "self.differentiable was mutated to True after construction."
+            )
+
+        # Perf: hoist hyper-dict and self-attribute lookups out of the
+        # ``substeps * timesteps`` micro-loop. Each cached miss inside the
+        # loop costs ~80 ns × 1e7 ≈ 1 s per simulate; these aliases buy
+        # ~3-4 s at paper budget and are deliberate exceptions to R1.
         rho = float(params["rho"].item())
         mu = float(params["mu"].item())
         dt = self.hyper["dt"]
@@ -279,7 +218,7 @@ class BehaviorKirmansAnts(Behavior):
 
         x = float(self.prior["density"].item())
         x = min(max(x, eps_x), 1.0 - eps_x)
-        phi = self._lamperti_forward(x)
+        phi = math.asin(2.0 * x - 1.0)
         noise = torch.randn(
             substeps, generator=self._torch_rng, dtype=torch.float64
         ).numpy()
@@ -298,7 +237,7 @@ class BehaviorKirmansAnts(Behavior):
                     break
             if phi <= phi_min or phi >= phi_max:
                 phi = min(max(phi, phi_min + 1.0e-15), phi_max - 1.0e-15)
-            x = self._lamperti_inverse(phi)
+            x = 0.5 * (1.0 + math.sin(phi))
             x = min(max(x, eps_x), 1.0 - eps_x)
             if record_inner:
                 buffer[t * substeps + k] = x

--- a/src/macrostat/models/KirmansAnts/behavior.py
+++ b/src/macrostat/models/KirmansAnts/behavior.py
@@ -8,21 +8,33 @@ The Quarterly Journal of Economics, 108(1), 137-156.
 Continuous-time large-N limit (see Moran et al. 2020) of the binary-choice
 recruitment dynamics: the fraction :math:`x_t \in [0, 1]` of ants at source A
 evolves under spontaneous switching at rate :math:`\rho` and herding at rate
-:math:`\mu`.
+:math:`\mu`. The :math:`x`-space Itô SDE is
 
-The macro-period ``step`` runs ``substeps = int(1/dt)`` Euler-Maruyama
-micro-steps with boundary rejection, mirroring the abmstat reference
-implementation in ``packages/abmstat/abmstat/models/kirmanants.py``. Phase 1
-of the migration replicates that implementation faithfully — including the
-boundary-rejection bias that suppresses the empirical density near
-:math:`x \in \{0, 1\}` in the bimodal regime.
+.. math::
+    dx_t = \rho\,(1 - 2 x_t)\, dt + \sqrt{2\,\mu\, x_t\,(1 - x_t)}\, dW_t.
 
-The model is non-differentiable: the rejection while-loop has no autograd
-path. ``BehaviorKirmansAnts.supports_differentiable = False`` so the base
-class refuses ``differentiable=True`` at construction.
+Naive Euler-Maruyama integration of this SDE has a worst-case
+:math:`O(\sqrt{dt})` weak bias near the boundary because the diffusion
+coefficient is only Hölder-1/2 at :math:`x \in \{0, 1\}`. The bias is most
+visible in the bimodal regime (:math:`\rho/\mu < 1`) where the stationary
+:math:`\text{Beta}(\rho/\mu, \rho/\mu)` density diverges at the endpoints.
+
+This module integrates the Lamperti-transformed SDE (Moran, Fosset,
+Benzaquen, Bouchaud 2020). Under :math:`\phi = \arcsin(2 x - 1)` the
+diffusion becomes constant :math:`= \sqrt{2\mu}`, so Euler-Maruyama in
+:math:`\phi` is Lipschitz and recovers the standard :math:`O(dt)` weak rate.
+Reflective boundary conditions are applied in :math:`\phi`-space at
+:math:`[-\pi/2,\,+\pi/2]`; the inverse map :math:`x = (1 + \sin\phi)/2`
+returns the density to its native interval before recording.
+
+The macro-period ``step`` runs ``substeps = int(1/dt)`` Lamperti micro-steps
+internally. The model is non-differentiable;
+``BehaviorKirmansAnts.supports_differentiable = False`` so the base class
+refuses ``differentiable=True`` at construction.
 """
 
 import logging
+import math
 
 import numpy as np
 import torch
@@ -36,19 +48,21 @@ logger = logging.getLogger(__name__)
 
 
 class BehaviorKirmansAnts(Behavior):
-    """Simulation logic for the Kirman ants SDE model.
+    r"""Simulation logic for the Kirman ants SDE model.
 
-    Each ``step()`` call runs ``substeps`` Euler-Maruyama micro-steps using
-    a boundary-rejection scheme to keep the density inside the open unit
-    interval. ``self.numpy_rng`` (set by the base class from the ``seed``
-    hyperparameter) is the per-instance ``numpy.random.Generator``; the
-    global ``np.random`` state is never touched.
+    Each ``step()`` call runs ``substeps`` Lamperti micro-steps via
+    :meth:`advance_lamperti`. ``self.numpy_rng`` (set by the base class from
+    ``hyper["seed"]``) is the per-instance primary
+    :class:`numpy.random.Generator`. Each macro-step consumes exactly
+    ``substeps`` Gaussians from this stream, so the noise stream is aligned
+    across the 5-point parameter stencil used by the downstream Fisher
+    information pipeline (paired-seed CRN).
 
-    With ``record_inner=True`` every micro-step is written to
-    ``self._micro_trajectory`` (float32, length ``timesteps * substeps``).
-    The base ``record_state`` continues to record one end-of-macro-period
-    value per outer step, so ``model.output["density"]`` keeps its standard
-    shape ``(timesteps, 1)``.
+    With ``record_inner=True`` every micro-step :math:`x` value is written
+    to ``self._micro_trajectory`` (float32, length
+    ``timesteps * substeps``). The Lamperti integrator integrates in
+    :math:`\phi`-space but inverse-maps to :math:`x` before recording, so
+    downstream KDE / FIM consumers stay method-agnostic.
     """
 
     version = "KirmansAnts"
@@ -79,22 +93,14 @@ class BehaviorKirmansAnts(Behavior):
             debug=debug,
         )
 
-        self._exhaustion_count: int = 0
         self._micro_trajectory: np.ndarray | None = None
 
-    @property
-    def exhaustion_count(self) -> int:
-        """Number of micro-steps where rejection sampling hit ``max_attempts``."""
-        return self._exhaustion_count
-
     def initialize(self):
-        """Set the initial density and (re)allocate the micro-trajectory buffer.
+        """Set initial density and allocate the micro-trajectory side-buffer.
 
-        Resets the exhaustion counter on every ``forward()`` call so multiple
-        runs of the same model instance report independent statistics.
+        Resets the per-run state on every ``forward()`` call so multiple
+        runs of the same model instance are independent.
         """
-        self._exhaustion_count = 0
-
         if self.hyper["record_inner"]:
             self._micro_trajectory = np.empty(
                 self.hyper["timesteps"] * self.hyper["substeps"],
@@ -108,7 +114,7 @@ class BehaviorKirmansAnts(Behavior):
         )
 
     def step(self, t: int, scenario: dict, params: dict | None = None, **kwargs):
-        """Advance the SDE by one macro-period of ``substeps`` Euler-Maruyama micro-steps.
+        """Advance the SDE by one macro-period.
 
         Parameters
         ----------
@@ -131,71 +137,147 @@ class BehaviorKirmansAnts(Behavior):
                 "BehaviorKirmansAnts is non-differentiable; "
                 "self.differentiable was mutated to True after construction."
             )
-        self.euler_maruyama_advance(t=t, scenario=scenario, params=params)
+        self.advance_lamperti(t=t, params=params)
 
-    def euler_maruyama_advance(
-        self, t: int, scenario: dict, params: dict | None = None
-    ):
-        r"""Run ``substeps`` Euler-Maruyama micro-steps with boundary rejection.
+    # --- Lamperti map helpers ----------------------------------------------
+
+    @staticmethod
+    def _lamperti_forward(x: float) -> float:
+        r"""Forward Lamperti map :math:`\phi = \arcsin(2 x - 1)`."""
+        return math.asin(2.0 * x - 1.0)
+
+    @staticmethod
+    def _lamperti_inverse(phi: float) -> float:
+        r"""Inverse Lamperti map :math:`x = (1 + \sin\phi)/2`."""
+        return 0.5 * (1.0 + math.sin(phi))
+
+    @staticmethod
+    def _lamperti_drift(x: float, rho: float, mu: float) -> float:
+        r"""Drift of the Lamperti-transformed SDE evaluated at the cached :math:`x`.
 
         Parameters
         ----------
-        t : int
-            Current macro-period index (used as the offset into the optional
-            micro-trajectory side-buffer).
-        scenario : dict
-            Scenario dictionary (not used).
-        params : dict | None
-            Parameter values for time t with scenario shocks already applied.
+        x : float
+            Current :math:`x`-space density (cached from previous inverse map).
+        rho : float
+            Spontaneous switching rate.
+        mu : float
+            Herding strength.
+
+        Returns
+        -------
+        float
+            :math:`\mu_\Phi(\phi)` evaluated at :math:`x`.
 
         Notes
         -----
-        Boundary rejection resamples only the noise draw (drift and diffusion
-        held fixed) until the proposed increment keeps the density strictly
-        inside :math:`(0, 1)`. On exhaustion the increment is set to zero and
-        ``self._exhaustion_count`` is incremented; this matches the abmstat
-        reference where the unbounded ``while True`` loop simply never
-        terminates if the geometry is degenerate.
+        Using :math:`\phi = f(x) = \arcsin(2 x - 1)` (Moran et al.\ 2020),
+        the Itô transform gives
+        :math:`\mu_\Phi = a(x) f'(x) + \tfrac{1}{2}\sigma^2(x) f''(x)`,
+        with constant-diffusion :math:`\sigma_\Phi \equiv \sqrt{2\mu}`. The
+        :math:`x`-form below is evaluated directly because :math:`x` is
+        already cached from the previous inverse map.
 
         Equations
         ---------
         .. math::
             \begin{align}
-                dx_t = \rho\,(1 - 2 x_t)\, dt
-                       + \sqrt{2 \mu\, x_t (1 - x_t)}\, dW_t
+                \mu_\Phi(\phi)
+                  = -(2\rho - \mu)\tan(\phi)
+                  = -\,\frac{(2\rho - \mu)\,(2 x - 1)}{2\sqrt{x(1 - x)}}.
+            \end{align}
+        """
+        return -(2.0 * rho - mu) * (2.0 * x - 1.0) / (2.0 * math.sqrt(x * (1.0 - x)))
+
+    # --- integrator --------------------------------------------------------
+
+    def advance_lamperti(self, t: int, params: dict):
+        r"""Run ``substeps`` Euler-Maruyama micro-steps in Lamperti space.
+
+        Parameters
+        ----------
+        t : int
+            Macro-period index.
+        params : dict
+            Parameter values at time t.
+
+        Notes
+        -----
+        Uses the Lamperti transform :math:`\phi = \arcsin(2 x - 1)` from
+        Moran, Fosset, Benzaquen, Bouchaud (2020). The diffusion in
+        :math:`\phi` is constant :math:`= \sqrt{2\mu}`, so Euler-Maruyama in
+        :math:`\phi` is Lipschitz and recovers the standard :math:`O(dt)`
+        weak rate. The :math:`\phi`-domain is :math:`[-\pi/2,\,+\pi/2]`;
+        reflective BC in :math:`\phi`-space is the geometrically correct
+        boundary condition.
+
+        :math:`x` is clipped to :math:`[\epsilon, 1 - \epsilon]` with
+        :math:`\epsilon = 10^{-7}` before the forward map and after the
+        inverse map. The clip sits above the float32 precision of the
+        side-buffer near the boundary and far below any KDE bandwidth used
+        downstream, so the clip is invisible to consumers.
+
+        ``_micro_trajectory`` stores :math:`x` (not :math:`\phi`); the
+        inverse map is applied at every substep so downstream consumers stay
+        method-agnostic.
+
+        Equations
+        ---------
+        .. math::
+            \begin{align}
+                \phi &= \arcsin(2 x - 1), \\
+                d\phi_t &= \mu_\Phi(\phi_t)\, dt + \sigma_\Phi\, dW_t,
+                  \quad \sigma_\Phi = \sqrt{2\mu}, \\
+                \mu_\Phi(\phi) &= -(2\rho - \mu)\tan(\phi)
+                  = -\,\frac{(2\rho - \mu)\,(2 x - 1)}{2\sqrt{x(1-x)}}, \\
+                x &= \tfrac{1}{2}\bigl(1 + \sin\phi\bigr).
             \end{align}
 
         Dependency
         ----------
-        - parameters: rho
-        - parameters: mu
-        - hyperparameters: dt
-        - hyperparameters: substeps
-        - hyperparameters: max_attempts
-        - hyperparameters: record_inner
+        - params: rho
+        - params: mu
+        - hyper: dt
+        - hyper: substeps
+        - hyper: record_inner
         - prior: density
 
         Sets
         -----
         - density
         """
-        x = float(self.prior["density"].item())
+        rho = float(params["rho"].item())
+        mu = float(params["mu"].item())
+        dt = self.hyper["dt"]
+        sqrt_dt = math.sqrt(dt)
+        sigma_phi = math.sqrt(2.0 * mu)
+        substeps = self.hyper["substeps"]
+        record_inner = self.hyper["record_inner"]
+        buffer = self._micro_trajectory
+        eps_x = 1.0e-7
+        phi_min = -0.5 * math.pi
+        phi_max = +0.5 * math.pi
 
-        for k in range(self.hyper["substeps"]):
-            drift = params["rho"].item() * (1.0 - 2.0 * x) * self.hyper["dt"]
-            diffusion = np.sqrt(2.0 * params["mu"].item() * x * (1.0 - x))
-            for _ in range(self.hyper["max_attempts"]):
-                dx = drift + diffusion * self.numpy_rng.standard_normal() * np.sqrt(
-                    self.hyper["dt"]
-                )
-                if 0.0 < x + dx < 1.0:
+        x = float(self.prior["density"].item())
+        x = min(max(x, eps_x), 1.0 - eps_x)
+        phi = self._lamperti_forward(x)
+        noise = self.numpy_rng.standard_normal(substeps)
+
+        for k in range(substeps):
+            drift_phi = self._lamperti_drift(x, rho, mu)
+            phi = phi + drift_phi * dt + sigma_phi * noise[k] * sqrt_dt
+            for _ in range(2):
+                if phi < phi_min:
+                    phi = 2.0 * phi_min - phi
+                elif phi > phi_max:
+                    phi = 2.0 * phi_max - phi
+                else:
                     break
-            else:
-                self._exhaustion_count += 1
-                logger.warning("max_attempts exhausted at t=%d, k=%d, x=%.6f", t, k, x)
-                dx = 0.0
-            x += dx
-            if self.hyper["record_inner"]:
-                self._micro_trajectory[t * self.hyper["substeps"] + k] = x
+            if phi <= phi_min or phi >= phi_max:
+                phi = min(max(phi, phi_min + 1.0e-15), phi_max - 1.0e-15)
+            x = self._lamperti_inverse(phi)
+            x = min(max(x, eps_x), 1.0 - eps_x)
+            if record_inner:
+                buffer[t * substeps + k] = x
 
         self.state["density"] = torch.full_like(self.state["density"], x)

--- a/src/macrostat/models/KirmansAnts/behavior.py
+++ b/src/macrostat/models/KirmansAnts/behavior.py
@@ -51,18 +51,29 @@ class BehaviorKirmansAnts(Behavior):
     r"""Simulation logic for the Kirman ants SDE model.
 
     Each ``step()`` call runs ``substeps`` Lamperti micro-steps via
-    :meth:`advance_lamperti`. ``self.numpy_rng`` (set by the base class from
-    ``hyper["seed"]``) is the per-instance primary
-    :class:`numpy.random.Generator`. Each macro-step consumes exactly
-    ``substeps`` Gaussians from this stream, so the noise stream is aligned
-    across the 5-point parameter stencil used by the downstream Fisher
-    information pipeline (paired-seed CRN).
+    :meth:`advance_lamperti`. ``self._torch_rng`` is a per-instance
+    :class:`torch.Generator` re-seeded from ``hyper["seed"]`` at every
+    :meth:`initialize` call. Each macro-step consumes exactly ``substeps``
+    Gaussians from this stream, so the noise stream is aligned across the
+    5-point parameter stencil used by the downstream Fisher information
+    pipeline (paired-seed CRN). The micro-step arithmetic itself uses
+    Python ``math.*`` on float64 scalars; per-step torch dispatch
+    overhead would dominate the cost at ``substeps = 1/dt = 10_000`` and
+    is reserved for the deferred batched-Lamperti refactor.
 
     With ``record_inner=True`` every micro-step :math:`x` value is written
     to ``self._micro_trajectory`` (float32, length
     ``timesteps * substeps``). The Lamperti integrator integrates in
     :math:`\phi`-space but inverse-maps to :math:`x` before recording, so
     downstream KDE / FIM consumers stay method-agnostic.
+
+    The model is non-differentiable: the reflective boundary condition
+    uses Python ``if`` on the scalar :math:`\phi`, and the macro-step
+    extracts ``params["rho"].item()`` / ``params["mu"].item()`` to feed
+    the scalar loop. Flipping ``supports_differentiable = True`` is
+    feasible via ``torch.clamp`` on :math:`\phi` and removal of the
+    ``.item()`` extraction, but pays the dispatch cost noted above and
+    is deferred to the batched-Lamperti dispatch.
     """
 
     version = "KirmansAnts"
@@ -94,12 +105,17 @@ class BehaviorKirmansAnts(Behavior):
         )
 
         self._micro_trajectory: np.ndarray | None = None
+        self._torch_rng: torch.Generator | None = None
 
     def initialize(self):
-        """Set initial density and allocate the micro-trajectory side-buffer.
+        """Set initial density, allocate the side-buffer, seed the RNG.
 
         Resets the per-run state on every ``forward()`` call so multiple
-        runs of the same model instance are independent.
+        runs of the same model instance are independent. The per-instance
+        :class:`torch.Generator` is created fresh and re-seeded from
+        ``hyper["seed"]`` here so two consecutive ``simulate()`` calls on
+        the same instance produce identical streams, mirroring the
+        base-class ``numpy_rng`` semantics.
         """
         if self.hyper["record_inner"]:
             self._micro_trajectory = np.empty(
@@ -108,6 +124,9 @@ class BehaviorKirmansAnts(Behavior):
             )
         else:
             self._micro_trajectory = None
+
+        self._torch_rng = torch.Generator()
+        self._torch_rng.manual_seed(int(self.hyper["seed"]))
 
         self.state["density"] = torch.full_like(
             self.state["density"], float(self.hyper["x0"])
@@ -261,10 +280,14 @@ class BehaviorKirmansAnts(Behavior):
         x = float(self.prior["density"].item())
         x = min(max(x, eps_x), 1.0 - eps_x)
         phi = self._lamperti_forward(x)
-        noise = self.numpy_rng.standard_normal(substeps)
+        noise = torch.randn(
+            substeps, generator=self._torch_rng, dtype=torch.float64
+        ).numpy()
 
         for k in range(substeps):
-            drift_phi = self._lamperti_drift(x, rho, mu)
+            drift_phi = (
+                -(2.0 * rho - mu) * (2.0 * x - 1.0) / (2.0 * math.sqrt(x * (1.0 - x)))
+            )
             phi = phi + drift_phi * dt + sigma_phi * noise[k] * sqrt_dt
             for _ in range(2):
                 if phi < phi_min:

--- a/src/macrostat/models/KirmansAnts/kirmansants.py
+++ b/src/macrostat/models/KirmansAnts/kirmansants.py
@@ -28,10 +28,11 @@ class KirmansAnts(Model):
     :math:`\\rho/\\mu > 1`, bimodal with mass at the boundaries for
     :math:`\\rho/\\mu < 1`.
 
-    Phase 1 mirrors the abmstat reference implementation
-    (``packages/abmstat/abmstat/models/kirmanants.py``): Euler-Maruyama
-    with boundary rejection. The model is non-differentiable; constructing
-    the behavior with ``differentiable=True`` raises ``RuntimeError``.
+    The integrator is Euler-Maruyama in the Lamperti-transformed
+    :math:`\\phi = \\arcsin(2 x - 1)` coordinate (Moran et al. 2020), with
+    reflective boundary conditions in :math:`\\phi`-space. The model is
+    non-differentiable; constructing the behavior with
+    ``differentiable=True`` raises ``RuntimeError``.
     """
 
     version = "KirmansAnts"

--- a/src/macrostat/models/KirmansAnts/parameters.py
+++ b/src/macrostat/models/KirmansAnts/parameters.py
@@ -1,12 +1,12 @@
 # SPDX-License-Identifier: MIT
 # SPDX-FileCopyrightText: 2026 Karl Naumann-Woleske
-"""Parameters class for the Kirman ants SDE model.
+r"""Parameters class for the Kirman ants SDE model.
 
 Reference: Kirman, A. (1993). "Ants, Rationality, and Recruitment".
 The Quarterly Journal of Economics, 108(1), 137-156.
 
 Continuous-time large-N limit (Moran et al. 2020) with a stationary
-:math:`\\text{Beta}(\\rho/\\mu, \\rho/\\mu)` distribution on :math:`x \\in [0, 1]`.
+:math:`\text{Beta}(\rho/\mu, \rho/\mu)` distribution on :math:`x \in [0, 1]`.
 """
 
 import logging
@@ -17,23 +17,28 @@ logger = logging.getLogger(__name__)
 
 
 class ParametersKirmansAnts(Parameters):
-    """Parameters for the Kirman ants SDE model.
+    r"""Parameters for the Kirman ants SDE model.
 
     Economic meaning:
-    - rho (>0): rate of spontaneous opinion switching ("self-conversion").
-    - mu (>0): herding strength (recruitment intensity).
 
-    The ratio rho/mu determines the regime: rho/mu > 1 unimodal at x=1/2,
-    rho/mu < 1 bimodal with mass near x=0 and x=1.
+    - ``rho`` (>0): rate of spontaneous opinion switching ("self-conversion").
+    - ``mu`` (>0): herding strength (recruitment intensity).
+
+    The ratio ``rho/mu`` determines the regime: ``rho/mu > 1`` is unimodal at
+    ``x = 1/2``, ``rho/mu = 1`` is uniform, ``rho/mu < 1`` is bimodal with
+    mass near ``x = 0`` and ``x = 1``.
 
     Hyperparameters control the simulation environment:
-    - timesteps: number of macro periods (each = 1 time unit of SDE evolution).
-    - dt: SDE micro-step size (Euler-Maruyama discretisation).
-    - substeps: number of micro-steps per macro period; must equal int(1/dt).
-    - x0: initial density.
-    - max_attempts: rejection-sampling cap inside one micro-step.
-    - record_inner: if True, every micro-step is written to a side-buffer
-      (size timesteps * substeps).
+
+    - ``timesteps``: number of macro periods (each one time unit of SDE
+      evolution).
+    - ``dt``: SDE micro-step size (Euler-Maruyama in Lamperti
+      :math:`\phi = \arcsin(2 x - 1)`-space).
+    - ``substeps``: number of micro-steps per macro period; must equal
+      ``int(1/dt)``.
+    - ``x0``: initial density.
+    - ``record_inner``: if True, every micro-step is written to a side-buffer
+      of size ``timesteps * substeps``.
     """
 
     version = "KirmansAnts"
@@ -79,7 +84,6 @@ class ParametersKirmansAnts(Parameters):
         hyper["dt"] = 1e-4
         hyper["substeps"] = 10000
         hyper["x0"] = 0.5
-        hyper["max_attempts"] = 1000
         hyper["record_inner"] = False
         return hyper
 
@@ -89,8 +93,9 @@ class ParametersKirmansAnts(Parameters):
         Raises
         ------
         ValueError
-            If ``dt`` is not in (0, 1), if ``substeps != int(1/dt)``, or if
-            ``x0`` is not strictly in (0, 1).
+            If ``dt`` is not in (0, 1), if ``1/dt`` is not integer-valued,
+            if ``substeps != int(1/dt)``, or if ``x0`` is not strictly in
+            (0, 1).
         """
         super().verify_parameters()
 

--- a/tests/models/test_kirmansants.py
+++ b/tests/models/test_kirmansants.py
@@ -48,7 +48,7 @@ def _stationary_sample(
     produces the noise. Aggregating across ``replicates`` independent
     seeds yields an empirical CDF that converges to the analytical Beta
     regardless of which RNG (numpy or torch) is wired up under
-    :meth:`BehaviorKirmansAnts.advance_lamperti`. Thinning at stride
+    :meth:`BehaviorKirmansAnts.step`. Thinning at stride
     ``stride`` keeps residual serial correlation below KS sensitivity.
     """
     samples = []
@@ -148,10 +148,11 @@ def test_reproducibility():
     "x", [1.0e-12, 1.0e-6, 0.25, 0.5, 0.75, 1.0 - 1.0e-6, 1.0 - 1.0e-12]
 )
 def test_lamperti_map_stable_near_boundaries(x):
-    phi = BehaviorKirmansAnts._lamperti_forward(x)
+    """Forward + inverse Lamperti map roundtrips cleanly near the boundaries."""
+    phi = math.asin(2.0 * x - 1.0)
     assert math.isfinite(phi)
     assert -0.5 * math.pi <= phi <= 0.5 * math.pi
-    x_back = BehaviorKirmansAnts._lamperti_inverse(phi)
+    x_back = 0.5 * (1.0 + math.sin(phi))
     assert math.isfinite(x_back)
     assert math.isclose(x_back, x, rel_tol=1.0e-9, abs_tol=1.0e-14)
 
@@ -159,30 +160,31 @@ def test_lamperti_map_stable_near_boundaries(x):
 @pytest.mark.parametrize("mu", [0.5, 1.0, 2.5])
 @pytest.mark.parametrize("rho", [0.1, 0.5, 1.0, 2.0])
 def test_lamperti_drift_matches_finite_difference(rho, mu):
-    """Confirm the analytical Lamperti drift equals the Itô-derived FD form."""
+    """The x-form drift used in step() equals the Itô-derived FD form."""
     for x in (0.1, 0.3, 0.5, 0.7, 0.9):
-        f_plus = BehaviorKirmansAnts._lamperti_forward(x + 1.0e-5)
-        f_minus = BehaviorKirmansAnts._lamperti_forward(x - 1.0e-5)
-        f_center = BehaviorKirmansAnts._lamperti_forward(x)
+        f_plus = math.asin(2.0 * (x + 1.0e-5) - 1.0)
+        f_minus = math.asin(2.0 * (x - 1.0e-5) - 1.0)
+        f_center = math.asin(2.0 * x - 1.0)
         fp = (f_plus - f_minus) / (2.0 * 1.0e-5)
         fpp = (f_plus - 2.0 * f_center + f_minus) / (1.0e-5 * 1.0e-5)
-        expected = rho * (1.0 - 2.0 * x) * fp + 0.5 * (2.0 * mu * x * (1.0 - x)) * fpp
         assert math.isclose(
-            BehaviorKirmansAnts._lamperti_drift(x, rho, mu),
-            expected,
+            -(2.0 * rho - mu) * (2.0 * x - 1.0) / (2.0 * math.sqrt(x * (1.0 - x))),
+            rho * (1.0 - 2.0 * x) * fp + 0.5 * (2.0 * mu * x * (1.0 - x)) * fpp,
             rel_tol=1.0e-4,
             abs_tol=1.0e-4,
         )
 
 
 def test_lamperti_drift_closed_form_in_phi():
-    """In phi-space the drift simplifies to -(2 rho - mu) * tan(phi)."""
+    """In phi-space the x-form drift equals -(2 rho - mu) * tan(phi)."""
     rho, mu = 0.5, 1.0
     for x in (0.1, 0.3, 0.5, 0.7, 0.9):
-        phi = BehaviorKirmansAnts._lamperti_forward(x)
-        expected = -(2.0 * rho - mu) * math.tan(phi)
-        got = BehaviorKirmansAnts._lamperti_drift(x, rho, mu)
-        assert math.isclose(got, expected, rel_tol=1.0e-9, abs_tol=1.0e-12)
+        assert math.isclose(
+            -(2.0 * rho - mu) * (2.0 * x - 1.0) / (2.0 * math.sqrt(x * (1.0 - x))),
+            -(2.0 * rho - mu) * math.tan(math.asin(2.0 * x - 1.0)),
+            rel_tol=1.0e-9,
+            abs_tol=1.0e-12,
+        )
 
 
 # --- drift symmetry -------------------------------------------------------

--- a/tests/models/test_kirmansants.py
+++ b/tests/models/test_kirmansants.py
@@ -30,33 +30,44 @@ from macrostat.models.KirmansAnts import (
 def _make_model(timesteps: int = 10, record_inner: bool = False, **hyper):
     extra = {"timesteps": timesteps, "record_inner": record_inner}
     extra.update(hyper)
-    parameters = ParametersKirmansAnts(hyperparameters=extra)
-    return KirmansAnts(parameters=parameters)
+    return KirmansAnts(parameters=ParametersKirmansAnts(hyperparameters=extra))
 
 
-def _stationary_sample(scenario_id: int, timesteps: int = 100):
-    """Run a single trajectory and return a thinned float64 stationary sample.
+def _stationary_sample(
+    scenario_id: int,
+    timesteps: int = 100,
+    replicates: int = 6,
+    seed_start: int = 42,
+    stride: int = 2000,
+):
+    """Aggregate independent-seed replicates into a stream-agnostic sample.
 
-    Thinning at stride 1000 keeps the autocorrelation of the returned sample
-    low enough that ``scipy.stats.ks_2samp`` against an analytical Beta draw
-    is calibrated; thinner strides at this budget leave residual serial
-    correlation that inflates the KS statistic.
+    A single-seed KS gate at this budget is calibration-fragile: the KS
+    statistic for any fixed seed lands somewhere in its null distribution,
+    so a threshold like ``pvalue > 0.01`` is sensitive to which RNG
+    produces the noise. Aggregating across ``replicates`` independent
+    seeds yields an empirical CDF that converges to the analytical Beta
+    regardless of which RNG (numpy or torch) is wired up under
+    :meth:`BehaviorKirmansAnts.advance_lamperti`. Thinning at stride
+    ``stride`` keeps residual serial correlation below KS sensitivity.
     """
-    model = _make_model(timesteps=timesteps, record_inner=True)
-    model.simulate(scenario=scenario_id)
-    micro = model.behavior_instance._micro_trajectory.astype(np.float64)
-    burn_in = micro.size // 10
-    return micro[burn_in::1000], model
+    samples = []
+    for seed in range(seed_start, seed_start + replicates):
+        model = _make_model(timesteps=timesteps, record_inner=True, seed=seed)
+        model.simulate(scenario=scenario_id)
+        micro = model.behavior_instance._micro_trajectory.astype(np.float64)
+        samples.append(micro[micro.size // 10 :: stride])
+    return np.concatenate(samples)
 
 
 # --- smoke / shape ---------------------------------------------------------
 
 
 def test_smoke_all_scenarios():
-    model = _make_model(timesteps=5)
     for scenario_id in (0, 1, 2):
-        out = model.simulate(scenario=scenario_id)
-        assert out["density"].shape == (6, 1)
+        assert _make_model(timesteps=5).simulate(scenario=scenario_id)[
+            "density"
+        ].shape == (6, 1)
 
 
 def test_density_in_unit_interval():
@@ -72,25 +83,25 @@ def test_density_in_unit_interval():
 
 def test_stationary_unimodal_ks():
     """Beta(2, 2): Lamperti recovers the analytical distribution."""
-    sample, _ = _stationary_sample(scenario_id=2)
-    reference = stats.beta(2.0, 2.0).rvs(size=sample.size, random_state=20260511)
-    pvalue = stats.ks_2samp(sample, reference).pvalue
+    pvalue = stats.ks_1samp(
+        _stationary_sample(scenario_id=2), stats.beta(2.0, 2.0).cdf
+    ).pvalue
     assert pvalue > 0.01, f"KS pvalue {pvalue:.4f} too small"
 
 
 def test_stationary_bimodal_ks():
     """Beta(0.5, 0.5): Lamperti removes the boundary bias seen under rejection."""
-    sample, _ = _stationary_sample(scenario_id=0)
-    reference = stats.beta(0.5, 0.5).rvs(size=sample.size, random_state=20260511)
-    pvalue = stats.ks_2samp(sample, reference).pvalue
+    pvalue = stats.ks_1samp(
+        _stationary_sample(scenario_id=0), stats.beta(0.5, 0.5).cdf
+    ).pvalue
     assert pvalue > 0.01, f"KS pvalue {pvalue:.4f} too small"
 
 
 def test_stationary_uniform_ks():
     """Beta(1, 1): the uniform regime."""
-    sample, _ = _stationary_sample(scenario_id=1)
-    reference = stats.beta(1.0, 1.0).rvs(size=sample.size, random_state=20260511)
-    pvalue = stats.ks_2samp(sample, reference).pvalue
+    pvalue = stats.ks_1samp(
+        _stationary_sample(scenario_id=1), stats.beta(1.0, 1.0).cdf
+    ).pvalue
     assert pvalue > 0.01, f"KS pvalue {pvalue:.4f} too small"
 
 
@@ -103,15 +114,16 @@ def test_stationary_uniform_ks():
 def test_stationary_paper_budget(scenario_id, shape):
     """KS-1samp against analytical Beta CDF at paper-figure budget.
 
-    Mirrors the regime panels in ``paper/figures/fig_ant_dynamics.pdf``.
-    ``timesteps=1000`` plus ``substeps=10_000`` gives the same trajectory
-    length the figure uses; thinning at stride 1000 produces ~10k
-    near-independent samples. Skipped by default (``pytest -m slow`` to
-    enable) because each scenario is ~minutes of wall-clock.
+    Long-horizon (``timesteps=1000``, ``substeps=10_000``) confirmation of
+    the convergence already verified at fast-test budget. Aggregates two
+    seeds for stream-agnostic calibration; runtime is ~minutes per
+    scenario, so this is intended for explicit invocation via ``pytest
+    -m slow`` and is not part of the routine gate.
     """
-    sample, _ = _stationary_sample(scenario_id=scenario_id, timesteps=1000)
-    cdf = stats.beta(shape, shape).cdf
-    pvalue = stats.ks_1samp(sample, cdf).pvalue
+    pvalue = stats.ks_1samp(
+        _stationary_sample(scenario_id=scenario_id, timesteps=1000, replicates=2),
+        stats.beta(shape, shape).cdf,
+    ).pvalue
     assert pvalue > 0.01, f"scenario={scenario_id} KS pvalue {pvalue:.4f} too small"
 
 
@@ -148,18 +160,19 @@ def test_lamperti_map_stable_near_boundaries(x):
 @pytest.mark.parametrize("rho", [0.1, 0.5, 1.0, 2.0])
 def test_lamperti_drift_matches_finite_difference(rho, mu):
     """Confirm the analytical Lamperti drift equals the Itô-derived FD form."""
-    h = 1.0e-5
     for x in (0.1, 0.3, 0.5, 0.7, 0.9):
-        f_plus = BehaviorKirmansAnts._lamperti_forward(x + h)
-        f_minus = BehaviorKirmansAnts._lamperti_forward(x - h)
+        f_plus = BehaviorKirmansAnts._lamperti_forward(x + 1.0e-5)
+        f_minus = BehaviorKirmansAnts._lamperti_forward(x - 1.0e-5)
         f_center = BehaviorKirmansAnts._lamperti_forward(x)
-        fp = (f_plus - f_minus) / (2.0 * h)
-        fpp = (f_plus - 2.0 * f_center + f_minus) / (h * h)
-        drift_x = rho * (1.0 - 2.0 * x)
-        sigma_sq = 2.0 * mu * x * (1.0 - x)
-        expected = drift_x * fp + 0.5 * sigma_sq * fpp
-        got = BehaviorKirmansAnts._lamperti_drift(x, rho, mu)
-        assert math.isclose(got, expected, rel_tol=1.0e-4, abs_tol=1.0e-4)
+        fp = (f_plus - f_minus) / (2.0 * 1.0e-5)
+        fpp = (f_plus - 2.0 * f_center + f_minus) / (1.0e-5 * 1.0e-5)
+        expected = rho * (1.0 - 2.0 * x) * fp + 0.5 * (2.0 * mu * x * (1.0 - x)) * fpp
+        assert math.isclose(
+            BehaviorKirmansAnts._lamperti_drift(x, rho, mu),
+            expected,
+            rel_tol=1.0e-4,
+            abs_tol=1.0e-4,
+        )
 
 
 def test_lamperti_drift_closed_form_in_phi():
@@ -177,8 +190,7 @@ def test_lamperti_drift_closed_form_in_phi():
 
 def test_drift_symmetry_stationary_mean():
     """Symmetric Beta has mean 1/2; empirical mean stays in tolerance."""
-    sample, _ = _stationary_sample(scenario_id=2, timesteps=200)
-    empirical_mean = float(np.mean(sample))
+    empirical_mean = float(np.mean(_stationary_sample(scenario_id=2, timesteps=200)))
     assert (
         abs(empirical_mean - 0.5) < 0.05
     ), f"mean {empirical_mean:.4f} too far from 0.5"
@@ -189,13 +201,11 @@ def test_drift_symmetry_stationary_mean():
 
 def test_differentiable_blocked_at_construction():
     parameters = ParametersKirmansAnts()
-    scenarios = ScenariosKirmansAnts(parameters=parameters)
-    variables = VariablesKirmansAnts(parameters=parameters)
     with pytest.raises(RuntimeError, match="supports_differentiable=False"):
         BehaviorKirmansAnts(
             parameters=parameters,
-            scenarios=scenarios,
-            variables=variables,
+            scenarios=ScenariosKirmansAnts(parameters=parameters),
+            variables=VariablesKirmansAnts(parameters=parameters),
             differentiable=True,
         )
 
@@ -218,8 +228,9 @@ def test_x0_validation_rejects_boundary():
 def test_record_inner_buffer_shape():
     model = _make_model(timesteps=7, record_inner=True)
     model.simulate()
-    expected = 7 * model.parameters.hyper["substeps"]
-    assert model.behavior_instance._micro_trajectory.shape == (expected,)
+    assert model.behavior_instance._micro_trajectory.shape == (
+        7 * model.parameters.hyper["substeps"],
+    )
     assert model.behavior_instance._micro_trajectory.dtype == np.float32
 
 

--- a/tests/models/test_kirmansants.py
+++ b/tests/models/test_kirmansants.py
@@ -2,16 +2,21 @@
 # SPDX-FileCopyrightText: 2026 Karl Naumann-Woleske
 """Targeted tests for the KirmansAnts SDE model.
 
-The model is a numpy Euler-Maruyama clone of the abmstat reference
-implementation (``packages/abmstat/abmstat/models/kirmanants.py``). Tests
-exercise: construction validation, the differentiability gate, the
-boundary-rejection guard, reproducibility under fixed seed, and the
-stationary distribution match for the unimodal regime.
+The model integrates the large-N continuous-limit Kirman SDE via the
+Lamperti transform :math:`\\phi = \\arcsin(2 x - 1)` (Moran et al. 2020),
+which yields constant diffusion :math:`\\sqrt{2\\mu}` and recovers
+:math:`O(dt)` weak convergence. Tests exercise construction validation, the
+differentiability gate, reproducibility under fixed seed, the Lamperti map
+roundtrip and analytical helpers, and the stationary distribution match
+against an analytical Beta sample via ``scipy.stats.ks_2samp`` /
+``scipy.stats.ks_1samp``.
 """
+
+import math
 
 import numpy as np
 import pytest
-from scipy.stats import kstest
+from scipy import stats
 
 from macrostat.models.KirmansAnts import (
     BehaviorKirmansAnts,
@@ -29,6 +34,24 @@ def _make_model(timesteps: int = 10, record_inner: bool = False, **hyper):
     return KirmansAnts(parameters=parameters)
 
 
+def _stationary_sample(scenario_id: int, timesteps: int = 100):
+    """Run a single trajectory and return a thinned float64 stationary sample.
+
+    Thinning at stride 1000 keeps the autocorrelation of the returned sample
+    low enough that ``scipy.stats.ks_2samp`` against an analytical Beta draw
+    is calibrated; thinner strides at this budget leave residual serial
+    correlation that inflates the KS statistic.
+    """
+    model = _make_model(timesteps=timesteps, record_inner=True)
+    model.simulate(scenario=scenario_id)
+    micro = model.behavior_instance._micro_trajectory.astype(np.float64)
+    burn_in = micro.size // 10
+    return micro[burn_in::1000], model
+
+
+# --- smoke / shape ---------------------------------------------------------
+
+
 def test_smoke_all_scenarios():
     model = _make_model(timesteps=5)
     for scenario_id in (0, 1, 2):
@@ -44,43 +67,124 @@ def test_density_in_unit_interval():
     assert (micro < 1.0).all()
 
 
+# --- stationary distribution -----------------------------------------------
+
+
 def test_stationary_unimodal_ks():
-    model = _make_model(timesteps=100, record_inner=True)
-    model.simulate(scenario=2)  # unimodal: rho=2.0, mu=1.0 -> Beta(2, 2)
-    micro = model.behavior_instance._micro_trajectory.astype(np.float64)
-    burn_in = micro.size // 10
-    sample = micro[burn_in::100]
-    statistic, _ = kstest(sample, "beta", args=(2.0, 2.0))
-    assert statistic < 0.05, f"KS statistic {statistic:.4f} too large"
+    """Beta(2, 2): Lamperti recovers the analytical distribution."""
+    sample, _ = _stationary_sample(scenario_id=2)
+    reference = stats.beta(2.0, 2.0).rvs(size=sample.size, random_state=20260511)
+    pvalue = stats.ks_2samp(sample, reference).pvalue
+    assert pvalue > 0.01, f"KS pvalue {pvalue:.4f} too small"
 
 
-@pytest.mark.xfail(
-    reason=(
-        "Boundary-rejection bias suppresses density near x in {0, 1}; the "
-        "bimodal Beta(0.5, 0.5) diverges at the boundaries. Phase-2 dispatch "
-        "addresses the bias."
-    ),
-    strict=False,
-)
 def test_stationary_bimodal_ks():
-    model = _make_model(timesteps=100, record_inner=True)
-    model.simulate(scenario=0)  # bimodal: rho=0.5, mu=1.0 -> Beta(0.5, 0.5)
-    micro = model.behavior_instance._micro_trajectory.astype(np.float64)
-    burn_in = micro.size // 10
-    sample = micro[burn_in::100]
-    statistic, _ = kstest(sample, "beta", args=(0.5, 0.5))
-    assert statistic < 0.05
+    """Beta(0.5, 0.5): Lamperti removes the boundary bias seen under rejection."""
+    sample, _ = _stationary_sample(scenario_id=0)
+    reference = stats.beta(0.5, 0.5).rvs(size=sample.size, random_state=20260511)
+    pvalue = stats.ks_2samp(sample, reference).pvalue
+    assert pvalue > 0.01, f"KS pvalue {pvalue:.4f} too small"
+
+
+def test_stationary_uniform_ks():
+    """Beta(1, 1): the uniform regime."""
+    sample, _ = _stationary_sample(scenario_id=1)
+    reference = stats.beta(1.0, 1.0).rvs(size=sample.size, random_state=20260511)
+    pvalue = stats.ks_2samp(sample, reference).pvalue
+    assert pvalue > 0.01, f"KS pvalue {pvalue:.4f} too small"
+
+
+@pytest.mark.slow
+@pytest.mark.parametrize(
+    "scenario_id,shape",
+    [(0, 0.5), (1, 1.0), (2, 2.0)],
+    ids=["bimodal", "uniform", "unimodal"],
+)
+def test_stationary_paper_budget(scenario_id, shape):
+    """KS-1samp against analytical Beta CDF at paper-figure budget.
+
+    Mirrors the regime panels in ``paper/figures/fig_ant_dynamics.pdf``.
+    ``timesteps=1000`` plus ``substeps=10_000`` gives the same trajectory
+    length the figure uses; thinning at stride 1000 produces ~10k
+    near-independent samples. Skipped by default (``pytest -m slow`` to
+    enable) because each scenario is ~minutes of wall-clock.
+    """
+    sample, _ = _stationary_sample(scenario_id=scenario_id, timesteps=1000)
+    cdf = stats.beta(shape, shape).cdf
+    pvalue = stats.ks_1samp(sample, cdf).pvalue
+    assert pvalue > 0.01, f"scenario={scenario_id} KS pvalue {pvalue:.4f} too small"
+
+
+# --- reproducibility -------------------------------------------------------
 
 
 def test_reproducibility():
-    model_a = _make_model(timesteps=10, record_inner=True)
-    model_b = _make_model(timesteps=10, record_inner=True)
-    model_a.simulate()
-    model_b.simulate()
+    a = _make_model(timesteps=10, record_inner=True)
+    b = _make_model(timesteps=10, record_inner=True)
+    a.simulate()
+    b.simulate()
     np.testing.assert_array_equal(
-        model_a.behavior_instance._micro_trajectory,
-        model_b.behavior_instance._micro_trajectory,
+        a.behavior_instance._micro_trajectory,
+        b.behavior_instance._micro_trajectory,
     )
+
+
+# --- Lamperti map ---------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "x", [1.0e-12, 1.0e-6, 0.25, 0.5, 0.75, 1.0 - 1.0e-6, 1.0 - 1.0e-12]
+)
+def test_lamperti_map_stable_near_boundaries(x):
+    phi = BehaviorKirmansAnts._lamperti_forward(x)
+    assert math.isfinite(phi)
+    assert -0.5 * math.pi <= phi <= 0.5 * math.pi
+    x_back = BehaviorKirmansAnts._lamperti_inverse(phi)
+    assert math.isfinite(x_back)
+    assert math.isclose(x_back, x, rel_tol=1.0e-9, abs_tol=1.0e-14)
+
+
+@pytest.mark.parametrize("mu", [0.5, 1.0, 2.5])
+@pytest.mark.parametrize("rho", [0.1, 0.5, 1.0, 2.0])
+def test_lamperti_drift_matches_finite_difference(rho, mu):
+    """Confirm the analytical Lamperti drift equals the Itô-derived FD form."""
+    h = 1.0e-5
+    for x in (0.1, 0.3, 0.5, 0.7, 0.9):
+        f_plus = BehaviorKirmansAnts._lamperti_forward(x + h)
+        f_minus = BehaviorKirmansAnts._lamperti_forward(x - h)
+        f_center = BehaviorKirmansAnts._lamperti_forward(x)
+        fp = (f_plus - f_minus) / (2.0 * h)
+        fpp = (f_plus - 2.0 * f_center + f_minus) / (h * h)
+        drift_x = rho * (1.0 - 2.0 * x)
+        sigma_sq = 2.0 * mu * x * (1.0 - x)
+        expected = drift_x * fp + 0.5 * sigma_sq * fpp
+        got = BehaviorKirmansAnts._lamperti_drift(x, rho, mu)
+        assert math.isclose(got, expected, rel_tol=1.0e-4, abs_tol=1.0e-4)
+
+
+def test_lamperti_drift_closed_form_in_phi():
+    """In phi-space the drift simplifies to -(2 rho - mu) * tan(phi)."""
+    rho, mu = 0.5, 1.0
+    for x in (0.1, 0.3, 0.5, 0.7, 0.9):
+        phi = BehaviorKirmansAnts._lamperti_forward(x)
+        expected = -(2.0 * rho - mu) * math.tan(phi)
+        got = BehaviorKirmansAnts._lamperti_drift(x, rho, mu)
+        assert math.isclose(got, expected, rel_tol=1.0e-9, abs_tol=1.0e-12)
+
+
+# --- drift symmetry -------------------------------------------------------
+
+
+def test_drift_symmetry_stationary_mean():
+    """Symmetric Beta has mean 1/2; empirical mean stays in tolerance."""
+    sample, _ = _stationary_sample(scenario_id=2, timesteps=200)
+    empirical_mean = float(np.mean(sample))
+    assert (
+        abs(empirical_mean - 0.5) < 0.05
+    ), f"mean {empirical_mean:.4f} too far from 0.5"
+
+
+# --- legacy validation -----------------------------------------------------
 
 
 def test_differentiable_blocked_at_construction():
@@ -109,12 +213,6 @@ def test_dt_validation_rejects_inconsistent_substeps():
 def test_x0_validation_rejects_boundary():
     with pytest.raises(ValueError, match="x0 must be strictly in"):
         ParametersKirmansAnts(hyperparameters={"x0": 0.0})
-
-
-def test_no_exhaustion_at_defaults():
-    model = _make_model(timesteps=20)
-    model.simulate()
-    assert model.behavior_instance.exhaustion_count == 0
 
 
 def test_record_inner_buffer_shape():


### PR DESCRIPTION
## Summary

- Replace the Euler-Maruyama-with-boundary-rejection inner loop with a Lamperti-transformed SDE (`phi = arcsin(2x - 1)`) and a reflective boundary in phi-space. Diffusion is constant in phi, so Euler-Maruyama recovers `O(dt)` weak convergence. The `exhaustion_count` path is removed.
- Switch the noise source from `numpy_rng.standard_normal` to a per-instance `torch.Generator`, allocated in `initialize()` and re-seeded from `self.hyper["seed"]`. Each macro-step draws `substeps` Gaussians as float64. The stream is paired-seed CRN aligned across the parameter stencil.
- Collapse the one-line `step()` wrapper into a single method. Inline `_lamperti_forward` (one call site) and `_lamperti_inverse` (1e7 calls per simulate, about 0.5 s saved). Drop `_lamperti_drift`. `behavior.py` shrinks from 106 to 47 lines net.
- A few hyper-dict and self-attribute reads are pulled out to local variables at the top of the inner loop. At `substeps = 10_000` this saves about 3 to 4 s per paper-budget simulate. A `# Perf:` comment marks them as intentional R1 exceptions.
- Recalibrate the stationary-distribution KS gates. The old gates used single-seed `ks_2samp` against a finite reference and were RNG-fragile: the numpy and torch streams landed in different quantiles of the null distribution under the same threshold. The new gates aggregate 6 independent-seed replicates and use `ks_1samp` against the analytical `Beta(rho/mu, rho/mu)` CDF, so they no longer depend on which RNG draws the noise.
- The `paper_budget` slow tests use 2 replicates at `timesteps=1000`. Ten single-use locals in the test file are inlined to clear R2 lint blockers.

## Test plan

- [x] `uv run pytest tests/models/test_kirmansants.py -v --override-ini="addopts="` — fast suite passes (33 passed, 3 slow deselected, 22 s)
- [x] `uv run pytest tests/models/test_kirmansants.py -m "not slow" --override-ini="addopts="` — confirms `paper_budget` markers skip cleanly
- [x] Stationary KS gates (`test_stationary_bimodal_ks`, `test_stationary_uniform_ks`) pass against the analytical Beta CDF with 6-replicate aggregation
- [x] Reproducibility test passes under the torch-Generator stream