### PR TITLE
ci(workflows): skip Coveralls upload on scheduled cron

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,6 +115,7 @@ jobs:
           fi
 
       - name: Upload coverage to Coveralls (parallel leg)
+        if: ${{ github.event_name != 'schedule' }}
         uses: coverallsapp/github-action@v2
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

The nightly cron tick on 2026-06-04 failed when coveralls.io returned a 503 to the per-leg upload. The `coverage-finish` aggregator is already gated by `if: github.event_name != 'schedule'`, so cron uploads were orphaned anyway. Matching the guard on the upload step removes both the wasted API calls and the flake surface.

## Type

ci

## What changed

- Added `if: ${{ github.event_name != 'schedule' }}` to the "Upload coverage to Coveralls (parallel leg)" step in `.github/workflows/ci.yml`. Mirrors the existing guard on the `coverage-finish` aggregator job.
- PR-time and push-to-master runs are unchanged. Only scheduled cron now skips the Coveralls leg.

## Quality assurance

- Triggered `workflow_dispatch` on the branch (run `26954691228`). All six matrix legs and the `finalize Coveralls report` job pass; the upload step still runs on non-schedule events.
- The failing nightly run (`26933391334`) was re-run unchanged and now passes, confirming the original failure was a transient 503 from coveralls.io rather than a code regression.
- Backward compatibility: preserved for PR-time and push-to-master flows.